### PR TITLE
fix: handle WSL command failures properly in wsl-manager

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,8 @@
       "Bash(gh pr checks:*)",
       "Bash(gh run view:*)",
       "Bash(Select-String -Pattern \"^\\[-\\]|Error|Failed|FAIL\" -Context 2,2)",
-      "Bash(powershell -File \".\\tests\\bin\\test-all.ps1\")"
+      "Bash(powershell -File \".\\tests\\bin\\test-all.ps1\")",
+      "Bash(git push)"
     ],
     "deny": [],
     "ask": []

--- a/tools/pslib/wsl.Tests.ps1
+++ b/tools/pslib/wsl.Tests.ps1
@@ -201,6 +201,17 @@ Describe "Remove-WslDistro" {
 
             Should -Invoke Invoke-CommandLine -ParameterFilter { $CommandLine -eq "wsl --unregister Debian" }
         }
+
+        It "Should throw error when wsl command fails" {
+            Mock Test-WslInstalled { $true }
+            Mock Get-WslDistroList { @("Debian") }
+            Mock Invoke-CommandLine { 
+                $global:LASTEXITCODE = 1
+                throw "Command line call `"wsl --unregister Debian`" failed with exit code 1"
+            }
+
+            { Remove-WslDistro -Name "Debian" -Confirm:$false } | Should -Throw "*failed with exit code 1*"
+        }
     }
 }
 
@@ -324,6 +335,34 @@ Describe "New-WslDistro" {
             New-WslDistro -Name "Debian" -WhatIf
 
             Should -Invoke Invoke-CommandLine -Times 0
+        }
+
+        It "Should throw error and stop execution when wsl command fails" {
+            Mock Test-WslInstalled { $true }
+            Mock Get-WslAvailableDistro { @("Debian") }
+            Mock Get-WslDistroList { @() }
+            Mock Invoke-CommandLine { 
+                $global:LASTEXITCODE = 1
+                throw "Command line call `"wsl --install -d Debian --no-launch`" failed with exit code 1"
+            }
+
+            { New-WslDistro -Name "Debian" -Confirm:$false } | Should -Throw "*failed with exit code 1*"
+        }
+
+        It "Should not display success message when wsl command fails" {
+            Mock Test-WslInstalled { $true }
+            Mock Get-WslAvailableDistro { @("Debian") }
+            Mock Get-WslDistroList { @() }
+            Mock Invoke-CommandLine { 
+                $global:LASTEXITCODE = 1
+                throw "Command line call `"wsl --install -d Debian --no-launch`" failed with exit code 1"
+            }
+            Mock Write-Output {}
+
+            { New-WslDistro -Name "Debian" -Confirm:$false } | Should -Throw
+
+            # Verify success message was never written
+            Should -Invoke Write-Output -Times 0 -ParameterFilter { $InputObject -like "*Successfully created*" }
         }
     }
 }
@@ -457,6 +496,23 @@ Describe "Copy-WslDistro" {
             { Copy-WslDistro -SourceName "Debian" -TargetName "MyDebian" -Confirm:$false } | Should -Throw
 
             Should -Invoke Invoke-CommandLine -ParameterFilter { $CommandLine -like "wsl --import *" } -Times 0
+            Should -Invoke Remove-Item
+        }
+
+        It "Should clean up temp file when import fails" {
+            Mock Test-WslInstalled { $true }
+            Mock Get-WslDistroList { @("Debian") }
+            Mock Invoke-CommandLine {} -ParameterFilter { $CommandLine -like "wsl --export *" }
+            Mock Invoke-CommandLine { 
+                $global:LASTEXITCODE = 1
+                throw "Command line call failed with exit code 1" 
+            } -ParameterFilter { $CommandLine -like "wsl --import *" }
+            Mock Test-Path { $true }
+            Mock Remove-Item {}
+
+            { Copy-WslDistro -SourceName "Debian" -TargetName "MyDebian" -Confirm:$false } | Should -Throw
+
+            # Verify temp file cleanup still happens
             Should -Invoke Remove-Item
         }
     }

--- a/tools/wsl/wsl-manager.bat
+++ b/tools/wsl/wsl-manager.bat
@@ -1,0 +1,1 @@
+pwsh -ExecutionPolicy Bypass -File %~dp0wsl-manager.ps1 %* || exit /b 1

--- a/tools/wsl/wsl-manager.ps1
+++ b/tools/wsl/wsl-manager.ps1
@@ -57,9 +57,18 @@ param(
     [string]$TargetName = ""
 )
 
+# Always set the $InformationPreference variable to "Continue" globally,
+# this way it gets printed on execution and continues execution afterwards.
+$InformationPreference = "Continue"
+
+# Stop on first error
+$ErrorActionPreference = "Stop"
+
 # Source dependencies
 . "$PSScriptRoot\..\pslib\utils.ps1"
 . "$PSScriptRoot\..\pslib\wsl.ps1"
+
+#region Functions
 
 function Show-WslDistroList {
     <#
@@ -410,7 +419,12 @@ function Invoke-WslManager {
     }
 }
 
-# Main execution - only run if script is executed directly (not dot-sourced)
+#endregion
+
+#region  Main execution - only run if script is executed directly (not dot-sourced)
+
 if ($MyInvocation.InvocationName -ne '.') {
     Invoke-WslManager -Command $Command -Name $Name -TargetName $TargetName
 }
+
+#endregion


### PR DESCRIPTION
- Add ErrorActionPreference=Stop to wsl-manager.ps1 to convert Write-Error into terminating errors
- Add InformationPreference=Continue for consistent output handling
- Add comprehensive tests for command failure scenarios in New-WslDistro, Remove-WslDistro, and Copy-WslDistro
- Organize wsl-manager.ps1 with #region tags for functions and main execution
- Fixes issue where success message was shown even when WSL command failed