### PR TITLE
feat(ci): normalize JUnit XML paths for Codecov Test Analytics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
           files: "${{ env.SHORTCUTS_DIR }}/test/out/junit.xml"
           flags: ${{ matrix.shell_label }}
           token: ${{ secrets.CODECOV_TOKEN }}
-          report-type: test_results
+          report_type: test_results
           fail_ci_if_error: true
 
       - name: Publish Test Report

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -101,6 +101,28 @@ Podman provides a daemonless, rootless container runtime compatible with Docker 
 
 ## DONE
 
+### [CI-002] ✅ COMPLETED - Normalize JUnit XML paths for Codecov Test Analytics
+
+**Status**: **Completed** (2026-02-21) | **Branch**: `feature/ci-001-normalize-junit-xml`
+**Priority**: Low
+**Component**: `test/bin/testrunner.ps1`, `test/bin/testrunner.Tests.ps1` (new)
+
+**Description**:
+Codecov's test-results-parser cannot properly process Pester's JUnit XML output because Pester embeds absolute Windows paths (with backslashes and drive letters) into `testsuite name/package`, `testcase classname`, and `testcase name` attributes. Added `ConvertTo-RelativeJUnitXml` helper to post-process the JUnit XML after Pester generates it, stripping the repo root prefix and converting backslashes to forward slashes.
+
+**Acceptance Criteria**:
+- [x] `ConvertTo-RelativeJUnitXml` helper function added to `testrunner.ps1`
+- [x] Strips repo root from `testsuite` `name` and `package` attributes
+- [x] Strips repo root from `testcase` `classname` and `name` attributes
+- [x] Converts backslashes to forward slashes in all normalized attributes
+- [x] Preserves non-path content in attributes (e.g., `.Shall not have deviations`)
+- [x] Handles trailing backslash on repo root (with and without)
+- [x] File is saved as valid XML
+- [x] Unit tests in `testrunner.Tests.ps1` (8 tests)
+- [x] All existing tests continue to pass (708 total)
+
+---
+
 ### [CI-001] ✅ COMPLETED - Upload code coverage and test results to Codecov
 
 **Status**: **Completed** (2026-02-21) | **Branch**: `feature/ci-codecov-upload`

--- a/test/bin/testrunner.Tests.ps1
+++ b/test/bin/testrunner.Tests.ps1
@@ -1,0 +1,170 @@
+﻿#Requires -Version 5.1
+#Requires -Modules @{ModuleName = 'Pester'; ModuleVersion = '5.7.1'}
+
+<#
+.SYNOPSIS
+    Tests for testrunner.ps1 helper functions.
+.DESCRIPTION
+    Unit tests for ConvertTo-RelativeJUnitXml and other testrunner helpers.
+#>
+
+BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\testrunner.ps1"
+}
+
+Describe 'ConvertTo-RelativeJUnitXml' {
+    BeforeEach {
+        $script:tempFile = Join-Path $TestDrive "junit.xml"
+    }
+
+    It 'Strips repo root from testsuite name and package attributes' {
+        $xml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="C:\Users\karst\shortcuts\test\bin\linter.Tests.ps1" package="C:\Users\karst\shortcuts\test\bin\linter.Tests.ps1">
+  </testsuite>
+</testsuites>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJUnitXml -Path $script:tempFile -RepoRoot 'C:\Users\karst\shortcuts'
+
+        [xml]$result = Get-Content $script:tempFile -Raw
+        $suite = $result.testsuites.testsuite
+        $suite.name | Should -Be 'test/bin/linter.Tests.ps1'
+        $suite.package | Should -Be 'test/bin/linter.Tests.ps1'
+    }
+
+    It 'Strips repo root from testcase classname attribute' {
+        $xml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="suite">
+    <testcase classname="C:\Users\karst\shortcuts\test\bin\linter.Tests.ps1" name="some test" />
+  </testsuite>
+</testsuites>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJUnitXml -Path $script:tempFile -RepoRoot 'C:\Users\karst\shortcuts'
+
+        [xml]$result = Get-Content $script:tempFile -Raw
+        $result.testsuites.testsuite.testcase.classname | Should -Be 'test/bin/linter.Tests.ps1'
+    }
+
+    It 'Strips repo root from testcase name attribute with embedded paths' {
+        $xml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="suite">
+    <testcase classname="cls" name="Analysis of file C:\Users\karst\shortcuts\tools\proxy\setProxy.ps1 against Script Analyzer Rules.Shall not have deviations" />
+  </testsuite>
+</testsuites>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJUnitXml -Path $script:tempFile -RepoRoot 'C:\Users\karst\shortcuts'
+
+        [xml]$result = Get-Content $script:tempFile -Raw
+        $result.testsuites.testsuite.testcase.name | Should -Be 'Analysis of file tools/proxy/setProxy.ps1 against Script Analyzer Rules.Shall not have deviations'
+    }
+
+    It 'Converts backslashes to forward slashes in all normalized attributes' {
+        $xml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="C:\Users\karst\shortcuts\tools\pslib\wsl\lib\core.Tests.ps1" package="C:\Users\karst\shortcuts\tools\pslib\wsl\lib\core.Tests.ps1">
+    <testcase classname="C:\Users\karst\shortcuts\tools\pslib\wsl\lib\core.Tests.ps1" name="some test" />
+  </testsuite>
+</testsuites>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJUnitXml -Path $script:tempFile -RepoRoot 'C:\Users\karst\shortcuts'
+
+        [xml]$result = Get-Content $script:tempFile -Raw
+        $suite = $result.testsuites.testsuite
+        $suite.name | Should -Be 'tools/pslib/wsl/lib/core.Tests.ps1'
+        $suite.package | Should -Be 'tools/pslib/wsl/lib/core.Tests.ps1'
+        $suite.testcase.classname | Should -Be 'tools/pslib/wsl/lib/core.Tests.ps1'
+    }
+
+    It 'Preserves non-path content in name attributes' {
+        $xml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="suite">
+    <testcase classname="cls" name="Some test without paths.Shall work fine" />
+  </testsuite>
+</testsuites>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJUnitXml -Path $script:tempFile -RepoRoot 'C:\Users\karst\shortcuts'
+
+        [xml]$result = Get-Content $script:tempFile -Raw
+        $result.testsuites.testsuite.testcase.name | Should -Be 'Some test without paths.Shall work fine'
+    }
+
+    It 'Handles trailing backslash on repo root' {
+        $xml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="C:\Users\karst\shortcuts\test\bin\linter.Tests.ps1" package="C:\Users\karst\shortcuts\test\bin\linter.Tests.ps1">
+  </testsuite>
+</testsuites>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJUnitXml -Path $script:tempFile -RepoRoot 'C:\Users\karst\shortcuts\'
+
+        [xml]$result = Get-Content $script:tempFile -Raw
+        $suite = $result.testsuites.testsuite
+        $suite.name | Should -Be 'test/bin/linter.Tests.ps1'
+        $suite.package | Should -Be 'test/bin/linter.Tests.ps1'
+    }
+
+    It 'Saves valid XML' {
+        $xml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="C:\Users\karst\shortcuts\test\bin\linter.Tests.ps1" package="C:\Users\karst\shortcuts\test\bin\linter.Tests.ps1">
+    <testcase classname="C:\Users\karst\shortcuts\test\bin\linter.Tests.ps1" name="test" />
+  </testsuite>
+</testsuites>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJUnitXml -Path $script:tempFile -RepoRoot 'C:\Users\karst\shortcuts'
+
+        # Should not throw when parsing as XML
+        { [xml](Get-Content $script:tempFile -Raw) } | Should -Not -Throw
+    }
+
+    It 'Handles multiple testsuites and testcases' {
+        $xml = @'
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="C:\Users\karst\shortcuts\test\bin\linter.Tests.ps1" package="C:\Users\karst\shortcuts\test\bin\linter.Tests.ps1">
+    <testcase classname="C:\Users\karst\shortcuts\test\bin\linter.Tests.ps1" name="test1" />
+    <testcase classname="C:\Users\karst\shortcuts\test\bin\linter.Tests.ps1" name="test2" />
+  </testsuite>
+  <testsuite name="C:\Users\karst\shortcuts\tools\pslib\utils\utils.Tests.ps1" package="C:\Users\karst\shortcuts\tools\pslib\utils\utils.Tests.ps1">
+    <testcase classname="C:\Users\karst\shortcuts\tools\pslib\utils\utils.Tests.ps1" name="test3" />
+  </testsuite>
+</testsuites>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJUnitXml -Path $script:tempFile -RepoRoot 'C:\Users\karst\shortcuts'
+
+        [xml]$result = Get-Content $script:tempFile -Raw
+        $suites = @($result.testsuites.testsuite)
+        $suites[0].name | Should -Be 'test/bin/linter.Tests.ps1'
+        $suites[0].package | Should -Be 'test/bin/linter.Tests.ps1'
+        $suites[1].name | Should -Be 'tools/pslib/utils/utils.Tests.ps1'
+        $suites[1].package | Should -Be 'tools/pslib/utils/utils.Tests.ps1'
+        @($suites[0].testcase)[0].classname | Should -Be 'test/bin/linter.Tests.ps1'
+        $suites[1].testcase.classname | Should -Be 'tools/pslib/utils/utils.Tests.ps1'
+    }
+}

--- a/test/bin/testrunner.ps1
+++ b/test/bin/testrunner.ps1
@@ -210,8 +210,8 @@ function ConvertTo-RelativeJUnitXml {
         [string]$RepoRoot
     )
 
-    # Resolve to absolute path and normalize trailing separator
-    $RepoRoot = (Resolve-Path $RepoRoot).Path.TrimEnd('\', '/')
+    # Normalize trailing separator
+    $RepoRoot = $RepoRoot.TrimEnd('\', '/')
     $escapedRoot = [regex]::Escape($RepoRoot + '\')
 
     [xml]$xml = Get-Content $Path -Raw
@@ -376,7 +376,7 @@ if ($MyInvocation.InvocationName -ne '.') {
             $exitCode = 1
         } else {
             if (Test-Path $ReportPath) {
-                ConvertTo-RelativeJUnitXml -Path $ReportPath -RepoRoot $repoRoot
+                ConvertTo-RelativeJUnitXml -Path $ReportPath -RepoRoot (Resolve-Path $repoRoot).Path
                 Write-Success "Test report generated at: $ReportPath"
             } else {
                 Write-Warning "Test report was not generated at: $ReportPath"

--- a/test/bin/testrunner.ps1
+++ b/test/bin/testrunner.ps1
@@ -192,6 +192,50 @@ function New-TestSummaryMarkdown {
     $markdownContent | Out-File -FilePath $OutputPath -Encoding UTF8 -Force
     Write-Output "`nTest summary markdown generated at: $OutputPath"
 }
+function ConvertTo-RelativeJUnitXml {
+    <#
+    .SYNOPSIS
+        Normalizes absolute Windows paths in JUnit XML to relative forward-slash paths.
+    .DESCRIPTION
+        Strips the repo root prefix from testsuite name/package and testcase classname/name
+        attributes, then converts backslashes to forward slashes. This enables Codecov's
+        test-results-parser to properly identify test files.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Function modifies a build artifact in-place, no confirmation needed')]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [string]$RepoRoot
+    )
+
+    # Resolve to absolute path and normalize trailing separator
+    $RepoRoot = (Resolve-Path $RepoRoot).Path.TrimEnd('\', '/')
+    $escapedRoot = [regex]::Escape($RepoRoot + '\')
+
+    [xml]$xml = Get-Content $Path -Raw
+
+    foreach ($suite in $xml.SelectNodes('//testsuite')) {
+        if ($suite.HasAttribute('name')) {
+            $suite.name = ($suite.name -replace $escapedRoot, '').Replace('\', '/')
+        }
+        if ($suite.HasAttribute('package')) {
+            $suite.package = ($suite.package -replace $escapedRoot, '').Replace('\', '/')
+        }
+    }
+
+    foreach ($tc in $xml.SelectNodes('//testcase')) {
+        if ($tc.HasAttribute('classname')) {
+            $tc.classname = ($tc.classname -replace $escapedRoot, '').Replace('\', '/')
+        }
+        if ($tc.HasAttribute('name')) {
+            $tc.name = ($tc.name -replace $escapedRoot, '').Replace('\', '/')
+        }
+    }
+
+    $xml.Save($Path)
+}
 #endregion
 
 if (-not $ReportPath) {
@@ -332,6 +376,7 @@ if ($MyInvocation.InvocationName -ne '.') {
             $exitCode = 1
         } else {
             if (Test-Path $ReportPath) {
+                ConvertTo-RelativeJUnitXml -Path $ReportPath -RepoRoot $repoRoot
                 Write-Success "Test report generated at: $ReportPath"
             } else {
                 Write-Warning "Test report was not generated at: $ReportPath"


### PR DESCRIPTION
## Summary

- Add `ConvertTo-RelativeJUnitXml` helper to `testrunner.ps1` that strips the repo root prefix and converts backslashes to forward slashes in JUnit XML `testsuite` and `testcase` attributes
- Enables Codecov's test-results-parser to properly identify test files from Pester's JUnit XML output (Pester embeds absolute Windows paths with drive letters and backslashes)
- Add 8 unit tests in new `testrunner.Tests.ps1` covering all normalization scenarios

## Test plan

- [x] All 708 unit tests pass (`pwsh -File .\test\bin\testrunner.ps1 -Unit`)
- [x] Verified `test/out/junit.xml` contains relative forward-slash paths after test run
- [x] CI passes on both PS7 and PS5.1 matrix entries
- [x] Codecov Test Analytics properly parses the normalized JUnit XML

🤖 Generated with [Claude Code](https://claude.com/claude-code)