### PR TITLE
feat(ci): normalize JaCoCo XML paths for Codecov coverage

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -101,6 +101,28 @@ Podman provides a daemonless, rootless container runtime compatible with Docker 
 
 ## DONE
 
+### [CI-003] ✅ COMPLETED - Normalize JaCoCo XML paths for Codecov coverage
+
+**Status**: **Completed** (2026-02-21) | **Branch**: `feature/ci-003-normalize-jacoco-xml`
+**Priority**: Low
+**Component**: `test/bin/testrunner.ps1`, `test/bin/testrunner.Tests.ps1`
+
+**Description**:
+Codecov could not display line-by-line coverage because Pester's JaCoCo XML embeds a common-parent-leaf prefix (e.g., `shortcuts/`) in package names and full relative paths in sourcefile names. Codecov constructs paths as `<package>/<sourcefile>`, producing doubled paths like `shortcuts/bin/bin/install.ps1`. Added `ConvertTo-RelativeJaCoCoXml` to strip the prefix and reduce sourcefile names to bare filenames. Also added `Import-XmlWithoutDtd` helper to handle JaCoCo's DOCTYPE declaration under strict mode.
+
+**Acceptance Criteria**:
+- [x] `ConvertTo-RelativeJaCoCoXml` helper function added to `testrunner.ps1`
+- [x] Strips common-parent-leaf prefix from `package` `name` attributes
+- [x] Strips common-parent-leaf prefix from `class` `name` attributes
+- [x] Reduces `sourcefile` `name` to bare filename
+- [x] Reduces `class` `sourcefilename` to bare filename
+- [x] Handles single and multiple packages
+- [x] File is saved as valid XML
+- [x] Unit tests in `testrunner.Tests.ps1` (7 tests)
+- [x] All existing tests continue to pass (715 total)
+
+---
+
 ### [CI-002] ✅ COMPLETED - Normalize JUnit XML paths for Codecov Test Analytics
 
 **Status**: **Completed** (2026-02-21) | **Branch**: `feature/ci-001-normalize-junit-xml`

--- a/test/bin/testrunner.Tests.ps1
+++ b/test/bin/testrunner.Tests.ps1
@@ -5,7 +5,8 @@
 .SYNOPSIS
     Tests for testrunner.ps1 helper functions.
 .DESCRIPTION
-    Unit tests for ConvertTo-RelativeJUnitXml and other testrunner helpers.
+    Unit tests for ConvertTo-RelativeJUnitXml, ConvertTo-RelativeJaCoCoXml,
+    and other testrunner helpers.
 #>
 
 BeforeAll {
@@ -166,5 +167,189 @@ Describe 'ConvertTo-RelativeJUnitXml' {
         $suites[1].package | Should -Be 'tools/pslib/utils/utils.Tests.ps1'
         @($suites[0].testcase)[0].classname | Should -Be 'test/bin/linter.Tests.ps1'
         $suites[1].testcase.classname | Should -Be 'tools/pslib/utils/utils.Tests.ps1'
+    }
+}
+
+Describe 'ConvertTo-RelativeJaCoCoXml' {
+    BeforeEach {
+        $script:tempFile = Join-Path $TestDrive "coverage.xml"
+    }
+
+    It 'Strips common-parent-leaf prefix from package name' {
+        $xml = @'
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"[]>
+<report name="Pester">
+  <package name="shortcuts/bin">
+    <sourcefile name="bin/install.ps1">
+      <counter type="LINE" missed="10" covered="5" />
+    </sourcefile>
+  </package>
+</report>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJaCoCoXml -Path $script:tempFile
+
+        $result = Import-XmlWithoutDtd -Path $script:tempFile
+        $result.report.package.name | Should -Be 'bin'
+    }
+
+    It 'Strips common-parent-leaf prefix from class name' {
+        $xml = @'
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"[]>
+<report name="Pester">
+  <package name="shortcuts/tools/proxy">
+    <class name="shortcuts/tools/proxy/setProxy" sourcefilename="tools/proxy/setProxy.ps1">
+      <counter type="LINE" missed="10" covered="5" />
+    </class>
+  </package>
+</report>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJaCoCoXml -Path $script:tempFile
+
+        $result = Import-XmlWithoutDtd -Path $script:tempFile
+        $result.report.package.class.name | Should -Be 'tools/proxy/setProxy'
+    }
+
+    It 'Reduces sourcefile name to bare filename' {
+        $xml = @'
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"[]>
+<report name="Pester">
+  <package name="shortcuts/tools/pslib/utils">
+    <sourcefile name="tools/pslib/utils/utils.ps1">
+      <counter type="LINE" missed="10" covered="5" />
+    </sourcefile>
+  </package>
+</report>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJaCoCoXml -Path $script:tempFile
+
+        $result = Import-XmlWithoutDtd -Path $script:tempFile
+        $result.report.package.sourcefile.name | Should -Be 'utils.ps1'
+    }
+
+    It 'Reduces class sourcefilename to bare filename' {
+        $xml = @'
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"[]>
+<report name="Pester">
+  <package name="shortcuts/bin">
+    <class name="shortcuts/bin/install" sourcefilename="bin/install.ps1">
+      <counter type="LINE" missed="10" covered="5" />
+    </class>
+  </package>
+</report>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJaCoCoXml -Path $script:tempFile
+
+        $result = Import-XmlWithoutDtd -Path $script:tempFile
+        $result.report.package.class.sourcefilename | Should -Be 'install.ps1'
+    }
+
+    It 'Handles multiple packages with classes and sourcefiles' {
+        $xml = @'
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"[]>
+<report name="Pester">
+  <package name="shortcuts/bin">
+    <class name="shortcuts/bin/install" sourcefilename="bin/install.ps1">
+      <counter type="LINE" missed="10" covered="5" />
+    </class>
+    <sourcefile name="bin/install.ps1">
+      <counter type="LINE" missed="10" covered="5" />
+    </sourcefile>
+  </package>
+  <package name="shortcuts/tools/pslib/wsl/lib">
+    <class name="shortcuts/tools/pslib/wsl/lib/core" sourcefilename="tools/pslib/wsl/lib/core.ps1">
+      <counter type="LINE" missed="20" covered="10" />
+    </class>
+    <class name="shortcuts/tools/pslib/wsl/lib/docker" sourcefilename="tools/pslib/wsl/lib/docker.ps1">
+      <counter type="LINE" missed="30" covered="15" />
+    </class>
+    <sourcefile name="tools/pslib/wsl/lib/core.ps1">
+      <counter type="LINE" missed="20" covered="10" />
+    </sourcefile>
+    <sourcefile name="tools/pslib/wsl/lib/docker.ps1">
+      <counter type="LINE" missed="30" covered="15" />
+    </sourcefile>
+  </package>
+</report>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJaCoCoXml -Path $script:tempFile
+
+        [xml]$result = Get-Content $script:tempFile -Raw
+        $pkgs = @($result.report.package)
+        $pkgs[0].name | Should -Be 'bin'
+        $pkgs[0].class.name | Should -Be 'bin/install'
+        $pkgs[0].class.sourcefilename | Should -Be 'install.ps1'
+        $pkgs[0].sourcefile.name | Should -Be 'install.ps1'
+        $pkgs[1].name | Should -Be 'tools/pslib/wsl/lib'
+        $classes = @($pkgs[1].class)
+        $classes[0].name | Should -Be 'tools/pslib/wsl/lib/core'
+        $classes[0].sourcefilename | Should -Be 'core.ps1'
+        $classes[1].name | Should -Be 'tools/pslib/wsl/lib/docker'
+        $classes[1].sourcefilename | Should -Be 'docker.ps1'
+        $srcs = @($pkgs[1].sourcefile)
+        $srcs[0].name | Should -Be 'core.ps1'
+        $srcs[1].name | Should -Be 'docker.ps1'
+    }
+
+    It 'Saves valid XML' {
+        $xml = @'
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"[]>
+<report name="Pester">
+  <package name="shortcuts/bin">
+    <class name="shortcuts/bin/install" sourcefilename="bin/install.ps1">
+      <counter type="LINE" missed="10" covered="5" />
+    </class>
+    <sourcefile name="bin/install.ps1">
+      <counter type="LINE" missed="10" covered="5" />
+    </sourcefile>
+  </package>
+</report>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJaCoCoXml -Path $script:tempFile
+
+        { Import-XmlWithoutDtd -Path $script:tempFile } | Should -Not -Throw
+    }
+
+    It 'Is idempotent when run twice' {
+        $xml = @'
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"[]>
+<report name="Pester">
+  <package name="shortcuts/bin">
+    <class name="shortcuts/bin/install" sourcefilename="bin/install.ps1">
+      <counter type="LINE" missed="10" covered="5" />
+    </class>
+    <sourcefile name="bin/install.ps1">
+      <counter type="LINE" missed="10" covered="5" />
+    </sourcefile>
+  </package>
+</report>
+'@
+        $xml | Out-File -FilePath $script:tempFile -Encoding UTF8
+
+        ConvertTo-RelativeJaCoCoXml -Path $script:tempFile
+        ConvertTo-RelativeJaCoCoXml -Path $script:tempFile
+
+        $result = Import-XmlWithoutDtd -Path $script:tempFile
+        $result.report.package.name | Should -Be 'bin'
+        $result.report.package.class.name | Should -Be 'bin/install'
+        $result.report.package.sourcefile.name | Should -Be 'install.ps1'
     }
 }

--- a/test/bin/testrunner.ps1
+++ b/test/bin/testrunner.ps1
@@ -297,22 +297,22 @@ function ConvertTo-RelativeJaCoCoXml {
 
     foreach ($pkg in $xml.SelectNodes('//package')) {
         if ($pkg.name.StartsWith($prefix)) {
-            $pkg.name = $pkg.name.Substring($prefix.Length)
+            $pkg.name = [string]$pkg.name.Substring($prefix.Length)
         }
     }
 
     foreach ($cls in $xml.SelectNodes('//class')) {
         if ($cls.HasAttribute('name') -and $cls.name.StartsWith($prefix)) {
-            $cls.name = $cls.name.Substring($prefix.Length)
+            $cls.name = [string]$cls.name.Substring($prefix.Length)
         }
         if ($cls.HasAttribute('sourcefilename')) {
-            $cls.sourcefilename = Split-Path $cls.sourcefilename -Leaf
+            $cls.sourcefilename = [string](Split-Path $cls.sourcefilename -Leaf)
         }
     }
 
     foreach ($src in $xml.SelectNodes('//sourcefile')) {
         if ($src.HasAttribute('name')) {
-            $src.name = Split-Path $src.name -Leaf
+            $src.name = [string](Split-Path $src.name -Leaf)
         }
     }
 

--- a/test/bin/testrunner.ps1
+++ b/test/bin/testrunner.ps1
@@ -236,6 +236,88 @@ function ConvertTo-RelativeJUnitXml {
 
     $xml.Save($Path)
 }
+
+function Import-XmlWithoutDtd {
+    <#
+    .SYNOPSIS
+        Loads an XML file while ignoring DTD processing.
+    .DESCRIPTION
+        JaCoCo XML files include a DOCTYPE declaration referencing report.dtd.
+        Under Set-StrictMode, the default [xml] cast fails to resolve properties
+        when DTD processing is attempted. This function uses XmlReaderSettings
+        to skip DTD validation.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $settings = New-Object System.Xml.XmlReaderSettings
+    $settings.DtdProcessing = [System.Xml.DtdProcessing]::Ignore
+    $reader = [System.Xml.XmlReader]::Create($Path, $settings)
+    try {
+        $doc = New-Object System.Xml.XmlDocument
+        $doc.Load($reader)
+        return $doc
+    } finally {
+        $reader.Close()
+    }
+}
+
+function ConvertTo-RelativeJaCoCoXml {
+    <#
+    .SYNOPSIS
+        Normalizes Pester JaCoCo XML paths so Codecov can resolve source files.
+    .DESCRIPTION
+        Pester's JaCoCo output uses a common-parent-leaf prefix (e.g., "shortcuts/")
+        in package and class names, and full relative paths in sourcefile names.
+        Codecov constructs paths as <package>/<sourcefile>, causing path duplication.
+        This function detects and strips the common prefix, and reduces sourcefile
+        and class sourcefilename attributes to bare filenames.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Function modifies a build artifact in-place, no confirmation needed')]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $xml = Import-XmlWithoutDtd -Path $Path
+
+    # Detect the common-parent-leaf prefix from the first package name.
+    # Pester prepends the repo folder name (e.g., "shortcuts/") to all packages.
+    $firstPkg = $xml.SelectSingleNode('//package')
+    if ($null -eq $firstPkg) { return }
+
+    $pkgName = $firstPkg.name
+    # The prefix is the first path segment followed by a slash (e.g., "shortcuts/")
+    $slashIndex = $pkgName.IndexOf('/')
+    if ($slashIndex -lt 0) { return }
+
+    $prefix = $pkgName.Substring(0, $slashIndex + 1)
+
+    foreach ($pkg in $xml.SelectNodes('//package')) {
+        if ($pkg.name.StartsWith($prefix)) {
+            $pkg.name = $pkg.name.Substring($prefix.Length)
+        }
+    }
+
+    foreach ($cls in $xml.SelectNodes('//class')) {
+        if ($cls.HasAttribute('name') -and $cls.name.StartsWith($prefix)) {
+            $cls.name = $cls.name.Substring($prefix.Length)
+        }
+        if ($cls.HasAttribute('sourcefilename')) {
+            $cls.sourcefilename = Split-Path $cls.sourcefilename -Leaf
+        }
+    }
+
+    foreach ($src in $xml.SelectNodes('//sourcefile')) {
+        if ($src.HasAttribute('name')) {
+            $src.name = Split-Path $src.name -Leaf
+        }
+    }
+
+    $xml.Save($Path)
+}
 #endregion
 
 if (-not $ReportPath) {
@@ -405,6 +487,7 @@ if ($MyInvocation.InvocationName -ne '.') {
                     Write-Output "  Coverage: $($coverageMetrics.Percent)%"
 
                     if (Test-Path $coverageXmlPath) {
+                        ConvertTo-RelativeJaCoCoXml -Path $coverageXmlPath
                         Write-Success "Coverage XML report generated at: $coverageXmlPath"
                     }
                 }


### PR DESCRIPTION
## Summary

- Add `ConvertTo-RelativeJaCoCoXml` helper to `testrunner.ps1` that fixes path duplication in Pester's JaCoCo XML output
- Pester embeds a `shortcuts/` prefix in package names and full relative paths in sourcefile names; Codecov constructs `<package>/<sourcefile>`, producing doubled paths like `shortcuts/bin/bin/install.ps1`
- Strips the common-parent-leaf prefix from package/class names and reduces sourcefile names to bare filenames
- Add `Import-XmlWithoutDtd` helper to handle JaCoCo's DOCTYPE declaration under `Set-StrictMode`
- Add 7 unit tests covering all normalization scenarios

## Test plan

- [x] All 715 unit tests pass (`pwsh -File .\test\bin\testrunner.ps1 -Unit`)
- [x] Verified `test/out/coverage.xml` contains correct paths after `-Coverage` run (e.g., `pkg=bin src=install.ps1`)
- [x] CI passes on both PS7 and PS5.1 matrix entries
- [ ] Codecov displays line-by-line coverage for all source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)