### PR TITLE
feat: add shutdown command to wsl-manager (SC-002)

### DIFF
--- a/docs/backlog/done/sc-002.md
+++ b/docs/backlog/done/sc-002.md
@@ -1,6 +1,6 @@
-# [SC-002] Add `shutdown` command to wsl-manager
+# [SC-002] ✅ COMPLETED - Add `shutdown` command to wsl-manager
 
-**Status**: Open
+**Status**: Completed (2026-03-06)
 **Priority**: Medium
 **Component**: `tools/pslib/wsl/wsl-manager.ps1`
 
@@ -14,16 +14,16 @@ The Podman setup documentation (`docs/wsl-manager.md`) instructs users to edit `
 - Command name: `shutdown` (mirrors `wsl --shutdown` semantics)
 - No distro name parameter — shuts down all of WSL
 - Should warn the user that all running distros will be stopped
-- Interactive menu: add `[S] Shutdown WSL` option
+- Interactive menu: add `[H] Shutdown WSL` option (`[S]` was already taken by "Setup user account")
 - SupportsShouldProcess for `-WhatIf` / `-Confirm` support
 
 **Acceptance Criteria**:
-- [ ] `wsl-manager shutdown` command executes `wsl.exe --shutdown`
-- [ ] Interactive menu option `[S] Shutdown WSL` available
-- [ ] Warning message before shutdown listing running distros (if any)
-- [ ] SupportsShouldProcess (`-WhatIf`, `-Confirm`) support
-- [ ] Idempotent — safe to run when no distros are running
-- [ ] `ValidateSet` and `Invoke-WslManager` switch updated
-- [ ] Unit tests
-- [ ] `docs/wsl-manager.md` updated to use `wsl-manager shutdown` instead of `wsl --shutdown`
-- [ ] All existing tests continue to pass
+- [x] `wsl-manager shutdown` command executes `wsl.exe --shutdown`
+- [x] Interactive menu option `[H] Shutdown WSL` available
+- [x] Warning message before shutdown listing running distros (if any)
+- [x] SupportsShouldProcess (`-WhatIf`, `-Confirm`) support
+- [x] Idempotent — safe to run when no distros are running
+- [x] `ValidateSet` and `Invoke-WslManager` switch updated
+- [x] Unit tests
+- [x] `docs/wsl-manager.md` updated to use `wsl-manager shutdown` instead of `wsl --shutdown`
+- [x] All existing tests continue to pass

--- a/docs/backlog/index.md
+++ b/docs/backlog/index.md
@@ -14,7 +14,6 @@
 - [SC-001 — Backlog refinement](in_progress/sc-001.md)
 
 ### TODO
-- [SC-002 — Add `shutdown` command to wsl-manager](todo/sc-002.md)
 - [SC-003 — Stop action functions from reprinting distro table](todo/sc-003.md)
 - [SC-005 — Move argument validation into action functions](todo/sc-005.md)
 - [SC-006 — Scoop Update Helper Script](todo/sc-006.md)
@@ -24,6 +23,7 @@
 - [SC-017 — Auto-terminate distros instead of prompting the user](todo/sc-017.md)
 
 ### Done
+- [SC-002 — Add `shutdown` command to wsl-manager](done/sc-002.md)
 - [SC-018 — Install Claude GitHub App and remove legacy workflows](done/sc-018.md)
 - [SC-014 — setup-user CLI does not accept -Username and -Password parameters](done/sc-014.md)
 - [SC-011 — WSL Manager: mask credentials and auto-terminate after install](done/sc-011.md)

--- a/docs/wsl-manager.md
+++ b/docs/wsl-manager.md
@@ -19,6 +19,7 @@ WSL Manager is a PowerShell tool for managing Windows Subsystem for Linux (WSL) 
   - [Setup Podman](#setup-podman)
   - [Remove Distribution](#remove-distribution)
   - [Terminate Distribution](#terminate-distribution)
+  - [Shutdown WSL](#shutdown-wsl)
 - [VS Code DevContainer Setup](#vs-code-devcontainer-setup)
 - [Technical Reference](#technical-reference)
 - [Additional Resources](#additional-resources)
@@ -121,6 +122,18 @@ Gracefully shut down a running distribution.
 - **Menu**: `[T] Terminate distribution`
 - **CLI**: `.\tools\pslib\wsl\wsl-manager.ps1 terminate <distro>`
 
+### Shutdown WSL
+
+Shut down the entire WSL subsystem including all running distributions and the WSL2 VM. Use this to apply changes to `%USERPROFILE%\.wslconfig`.
+
+- **Menu**: `[H] Shutdown WSL`
+- **CLI**: `.\tools\pslib\wsl\wsl-manager.ps1 shutdown`
+
+This command:
+- Lists any running distributions before shutting down (so you know what will be stopped)
+- Stops all running distributions and the WSL2 lightweight VM
+- Is idempotent — safe to run when no distributions are running
+
 ---
 
 ## VS Code DevContainer Setup
@@ -173,7 +186,7 @@ autoProxy=true
 Then restart WSL to apply:
 
 ```powershell
-wsl --shutdown
+.\tools\pslib\wsl\wsl-manager.ps1 shutdown
 ```
 
 #### Step 2: Install WSL Distribution
@@ -758,7 +771,7 @@ source ~/.bashrc
 **Solution:** Verify `%USERPROFILE%\.wslconfig` contains the `kernelCommandLine` from [Step 1](#step-1-configure-wsl-global-settings), then restart WSL:
 
 ```powershell
-wsl --shutdown
+.\tools\pslib\wsl\wsl-manager.ps1 shutdown
 ```
 
 #### Mount Propagation Warnings

--- a/tools/pslib/wsl/lib/commands.Tests.ps1
+++ b/tools/pslib/wsl/lib/commands.Tests.ps1
@@ -1577,3 +1577,72 @@ Describe "Invoke-TerminateDistro" {
     }
 }
 
+Describe "Invoke-ShutdownWsl" {
+    Context "When distributions are running" {
+        BeforeEach {
+            Mock Get-WslDistroList {
+                @(
+                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
+                    [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
+                )
+            } -ParameterFilter { $Detailed }
+            Mock Stop-WslSubsystem { }
+            Mock Write-Host { }
+        }
+
+        It "Should warn about running distributions" {
+            Invoke-ShutdownWsl
+
+            Should -Invoke Write-Host -ParameterFilter {
+                $Object -like "*Debian*" -and $ForegroundColor -eq "Yellow"
+            }
+        }
+
+        It "Should call Stop-WslSubsystem" {
+            Invoke-ShutdownWsl
+
+            Should -Invoke Stop-WslSubsystem -Times 1
+        }
+    }
+
+    Context "When no distributions are running" {
+        BeforeEach {
+            Mock Get-WslDistroList {
+                @(
+                    [PSCustomObject]@{ Name = "Debian"; State = "Stopped"; Version = 2; IsDefault = $true }
+                )
+            } -ParameterFilter { $Detailed }
+            Mock Stop-WslSubsystem { }
+            Mock Write-Host { }
+        }
+
+        It "Should not display warning" {
+            Invoke-ShutdownWsl
+
+            Should -Invoke Write-Host -ParameterFilter {
+                $ForegroundColor -eq "Yellow" -and $Object -like "*will be stopped*"
+            } -Times 0
+        }
+
+        It "Should still call Stop-WslSubsystem" {
+            Invoke-ShutdownWsl
+
+            Should -Invoke Stop-WslSubsystem -Times 1
+        }
+    }
+
+    Context "When no distributions are installed" {
+        BeforeEach {
+            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
+            Mock Stop-WslSubsystem { }
+            Mock Write-Host { }
+        }
+
+        It "Should call Stop-WslSubsystem" {
+            Invoke-ShutdownWsl
+
+            Should -Invoke Stop-WslSubsystem -Times 1
+        }
+    }
+}
+

--- a/tools/pslib/wsl/lib/commands.ps1
+++ b/tools/pslib/wsl/lib/commands.ps1
@@ -776,6 +776,31 @@ function Invoke-CloneDistro {
     Copy-WslDistro -SourceName $SourceName -TargetName $TargetName -Confirm:$false
 }
 
+function Invoke-ShutdownWsl {
+    <#
+    .SYNOPSIS
+        Handles the WSL shutdown workflow.
+    .DESCRIPTION
+        Warns the user about running distributions and shuts down the entire WSL subsystem.
+    #>
+    [CmdletBinding()]
+    param()
+
+    # List running distributions as a warning
+    $allDistros = @(Get-WslDistroList -Detailed)
+    $runningDistros = @($allDistros | Where-Object { $_.State -eq "Running" })
+
+    if ($runningDistros.Count -gt 0) {
+        Write-Host ""
+        Write-Host "Warning: The following distributions are currently running and will be stopped:" -ForegroundColor Yellow
+        foreach ($distro in $runningDistros) {
+            Write-Host "  - $($distro.Name)" -ForegroundColor Yellow
+        }
+    }
+
+    Stop-WslSubsystem -Confirm:$false
+}
+
 function Show-InteractiveMenu {
     <#
     .SYNOPSIS
@@ -816,6 +841,7 @@ function Show-InteractiveMenu {
         Write-Host "  [X] Setup proxy (corporate)" -ForegroundColor White
         Write-Host "  [R] Remove distribution" -ForegroundColor White
         Write-Host "  [T] Terminate distribution" -ForegroundColor White
+        Write-Host "  [H] Shutdown WSL" -ForegroundColor White
         Write-Host "  [Q] Quit" -ForegroundColor White
         Write-Host ""
 
@@ -903,6 +929,15 @@ function Show-InteractiveMenu {
                 }
                 Read-Host -Prompt "Press Enter to continue ..."
             }
+            "H" {
+                try {
+                    Invoke-ShutdownWsl
+                }
+                catch {
+                    Write-ErrorMsg "$_"
+                }
+                Read-Host -Prompt "Press Enter to continue ..."
+            }
             "Q" {
                 $continue = $false
             }
@@ -926,7 +961,7 @@ function Invoke-WslManager {
     [CmdletBinding()]
     param(
         [Parameter(Position = 0)]
-        [ValidateSet("list", "install", "clone", "remove", "update", "setup-user", "setup-proxy", "setup-docker", "setup-podman", "repair-interop", "terminate", "")]
+        [ValidateSet("list", "install", "clone", "remove", "update", "setup-user", "setup-proxy", "setup-docker", "setup-podman", "repair-interop", "terminate", "shutdown", "")]
         [string]$Command = "",
 
         [Parameter(Position = 1)]
@@ -1001,6 +1036,9 @@ function Invoke-WslManager {
             else {
                 Invoke-TerminateDistro -Name $Name
             }
+        }
+        "shutdown" {
+            Invoke-ShutdownWsl
         }
         default {
             Show-InteractiveMenu

--- a/tools/pslib/wsl/lib/ops.Tests.ps1
+++ b/tools/pslib/wsl/lib/ops.Tests.ps1
@@ -541,3 +541,141 @@ Describe "Update-WslDistro" {
         }
     }
 }
+
+Describe "Stop-WslSubsystem" {
+    Context "When distributions are running" {
+        BeforeEach {
+            Mock Get-WslDistroList {
+                @(
+                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
+                    [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
+                )
+            } -ParameterFilter { $Detailed }
+            Mock Invoke-CommandLine { }
+            Mock Write-Warning { }
+            Mock Write-Output { }
+        }
+
+        It "Should warn about running distributions" {
+            Stop-WslSubsystem -Confirm:$false
+
+            Should -Invoke Write-Warning -ParameterFilter {
+                $Message -like "*Debian*"
+            }
+        }
+
+        It "Should execute wsl.exe --shutdown" {
+            Stop-WslSubsystem -Confirm:$false
+
+            Should -Invoke Invoke-CommandLine -ParameterFilter {
+                $CommandLine -eq "wsl.exe --shutdown"
+            }
+        }
+    }
+
+    Context "When no distributions are running" {
+        BeforeEach {
+            Mock Get-WslDistroList {
+                @(
+                    [PSCustomObject]@{ Name = "Debian"; State = "Stopped"; Version = 2; IsDefault = $true }
+                )
+            } -ParameterFilter { $Detailed }
+            Mock Invoke-CommandLine { }
+            Mock Write-Warning { }
+            Mock Write-Output { }
+        }
+
+        It "Should not warn about running distributions" {
+            Stop-WslSubsystem -Confirm:$false
+
+            Should -Invoke Write-Warning -Times 0
+        }
+
+        It "Should still execute wsl.exe --shutdown" {
+            Stop-WslSubsystem -Confirm:$false
+
+            Should -Invoke Invoke-CommandLine -ParameterFilter {
+                $CommandLine -eq "wsl.exe --shutdown"
+            }
+        }
+
+        It "Should display idempotent message" {
+            Stop-WslSubsystem -Confirm:$false
+
+            Should -Invoke Write-Output -ParameterFilter {
+                $InputObject -like "*No distributions are currently running*"
+            }
+        }
+    }
+
+    Context "When no distributions are installed" {
+        BeforeEach {
+            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
+            Mock Invoke-CommandLine { }
+            Mock Write-Warning { }
+            Mock Write-Output { }
+        }
+
+        It "Should not warn and still execute shutdown" {
+            Stop-WslSubsystem -Confirm:$false
+
+            Should -Invoke Write-Warning -Times 0
+            Should -Invoke Invoke-CommandLine -ParameterFilter {
+                $CommandLine -eq "wsl.exe --shutdown"
+            }
+        }
+    }
+
+    Context "When ShouldProcess is used" {
+        BeforeEach {
+            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
+            Mock Invoke-CommandLine { }
+            Mock Write-Output { }
+        }
+
+        It "Should skip shutdown when user cancels with -WhatIf" {
+            Stop-WslSubsystem -WhatIf
+
+            Should -Invoke Invoke-CommandLine -Times 0
+        }
+    }
+
+    Context "When shutdown command fails" {
+        BeforeEach {
+            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
+            Mock Write-Output { }
+            Mock Invoke-CommandLine {
+                $global:LASTEXITCODE = 1
+                throw "Command line call `"wsl.exe --shutdown`" failed with exit code 1"
+            }
+        }
+
+        It "Should throw error when wsl command fails" {
+            { Stop-WslSubsystem -Confirm:$false } | Should -Throw "*failed with exit code 1*"
+        }
+    }
+
+    Context "When displaying output" {
+        BeforeEach {
+            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
+            Mock Invoke-CommandLine { }
+            Mock Write-Output { }
+        }
+
+        It "Should display shutdown progress message" {
+            Stop-WslSubsystem -Confirm:$false
+
+            Should -Invoke Write-Output -ParameterFilter {
+                $InputObject -like "*Shutting down WSL subsystem*"
+            }
+        }
+
+        It "Should display success message after shutdown" {
+            Stop-WslSubsystem -Confirm:$false
+
+            Should -Invoke Write-Output -ParameterFilter {
+                $InputObject -like "*WSL subsystem has been shut down*"
+            }
+        }
+    }
+}

--- a/tools/pslib/wsl/lib/ops.ps1
+++ b/tools/pslib/wsl/lib/ops.ps1
@@ -150,6 +150,52 @@ function Copy-WslDistro {
     }
 }
 
+function Stop-WslSubsystem {
+    <#
+    .SYNOPSIS
+        Shuts down the entire WSL subsystem including all running distributions.
+
+    .DESCRIPTION
+        Executes 'wsl.exe --shutdown' to stop the entire WSL 2 lightweight VM and all
+        running distributions. Unlike Stop-WslDistro (which terminates a single distro),
+        this stops WSL completely. Use this to apply changes to %USERPROFILE%\.wslconfig.
+
+    .EXAMPLE
+        Stop-WslSubsystem
+        Shuts down all of WSL after displaying a warning with running distributions.
+
+    .EXAMPLE
+        Stop-WslSubsystem -WhatIf
+        Shows what would happen without actually shutting down.
+
+    .NOTES
+        This operation is idempotent — safe to run when no distributions are running.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    param()
+
+    # List running distributions to warn the user
+    $allDistros = @(Get-WslDistroList -Detailed)
+    $runningDistros = @($allDistros | Where-Object { $_.State -eq "Running" })
+
+    if ($runningDistros.Count -gt 0) {
+        $runningNames = ($runningDistros | ForEach-Object { $_.Name }) -join ", "
+        Write-Warning "The following running distributions will be stopped: $runningNames"
+    }
+    else {
+        Write-Output "No distributions are currently running."
+    }
+
+    if ($PSCmdlet.ShouldProcess("WSL subsystem", "Shutdown all distributions and the WSL2 VM")) {
+        Write-Output "Shutting down WSL subsystem ..."
+        Invoke-CommandLine -CommandLine "wsl.exe --shutdown"
+        Write-Output "WSL subsystem has been shut down."
+    }
+    else {
+        Write-Output "Shutdown cancelled."
+    }
+}
+
 function Update-WslDistro {
     <#
     .SYNOPSIS

--- a/tools/pslib/wsl/wsl-manager.ps1
+++ b/tools/pslib/wsl/wsl-manager.ps1
@@ -9,7 +9,7 @@
     creating, and removing distributions.
 
 .PARAMETER Command
-    The command to execute: list, create, clone, remove, update, setup-user, setup-proxy, setup-docker, setup-podman, repair-interop, terminate.
+    The command to execute: list, create, clone, remove, update, setup-user, setup-proxy, setup-docker, setup-podman, repair-interop, terminate, shutdown.
     If not specified, enters interactive mode.
 
 .PARAMETER Name
@@ -60,7 +60,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Position = 0)]
-    [ValidateSet("list", "install", "clone", "remove", "update", "setup-user", "setup-proxy", "setup-docker", "setup-podman", "repair-interop", "terminate", "")]
+    [ValidateSet("list", "install", "clone", "remove", "update", "setup-user", "setup-proxy", "setup-docker", "setup-podman", "repair-interop", "terminate", "shutdown", "")]
     [string]$Command = "",
 
     [Parameter(Position = 1)]


### PR DESCRIPTION
Implements `wsl-manager shutdown` command that executes `wsl.exe --shutdown` to stop the entire WSL subsystem. Includes SupportsShouldProcess support, running distro warning, interactive menu option [H], and unit tests.

Closes #38

Generated with [Claude Code](https://claude.ai/code)