### PR TITLE
fix: SC-015 follow-ups — compat wrappers, bat fixes, backlog cleanup

### DIFF
--- a/.claude/skills/pester-exec/SKILL.md
+++ b/.claude/skills/pester-exec/SKILL.md
@@ -128,9 +128,20 @@ See [references/ai-agent-patterns.md](references/ai-agent-patterns.md) for:
 
 ## Troubleshooting Test Failures
 
-### When Tests Fail on a Feature Branch
+### CRITICAL: There Are No Pre-Existing Failures
 
-**Remember**: The `develop` branch is always green (CI enforces this).
+**The `develop` branch is always green. CI enforces this. Therefore, any test failure on a feature branch was caused by that branch — no exceptions.**
+
+**You MUST NOT:**
+- Dismiss failures as "pre-existing" or "unrelated to my changes"
+- Skip failing tests or proceed to commit with uninvestigated failures
+- Assume that tests in files you didn't directly modify can't be affected by your changes
+
+**You MUST:**
+- Investigate every failure
+- If uncertain whether your changes caused it, flag it to the user — never silently skip
+
+### When Tests Fail on a Feature Branch
 
 **If tests fail on your feature branch**:
 

--- a/.claude/skills/powershell-dev/references/testing-patterns.md
+++ b/.claude/skills/powershell-dev/references/testing-patterns.md
@@ -6,8 +6,13 @@ Common testing patterns for PowerShell code in this project.
 
 ```powershell
 BeforeAll {
-    # Source the module being tested
-    . "$PSScriptRoot/utils.ps1"
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
+    . "$PSScriptRoot\utils.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "FunctionName" {
@@ -15,15 +20,15 @@ Describe "FunctionName" {
         It "Should do behavior X" {
             # Arrange
             $input = "test"
-            
+
             # Act
             $result = FunctionName -Parameter $input
-            
+
             # Assert
             $result | Should -Be "expected"
         }
     }
-    
+
     Context "When condition B" {
         It "Should do behavior Y" {
             # Test implementation
@@ -228,17 +233,52 @@ Describe "Integration Test" {
         # Setup: Create test files, start services, etc.
         New-Item -Path "TestDrive:\test.txt" -ItemType File
     }
-    
+
     AfterAll {
         # Cleanup: Remove test files, stop services, etc.
         Remove-Item -Path "TestDrive:\test.txt" -Force
     }
-    
+
     It "Should use test file" {
         # Test implementation
     }
 }
 ```
+
+## Cross-File Test Isolation (MANDATORY)
+
+Pester runs all test files in the same PowerShell process. Functions loaded via dot-sourcing
+persist across files and cause flaky, order-dependent failures.
+
+**Every test file that dot-sources a library MUST use `Start-SutIsolation`/`Stop-SutIsolation`
+from `test/bin/lib/TestIsolation.ps1`:**
+
+```powershell
+BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
+    . "$PSScriptRoot\module.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
+}
+```
+
+`Start-SutIsolation` snapshots existing functions before dot-sourcing. `Stop-SutIsolation` removes
+any functions that were added, preventing leakage into subsequent test files.
+
+Multiple scripts can be dot-sourced after a single `Start-SutIsolation` call:
+```powershell
+Start-SutIsolation
+. "$PSScriptRoot\commands.ps1"
+. "$PSScriptRoot\manager.ps1"
+```
+
+**Why this matters:** Without cleanup, functions from file A leak into file B's test run.
+If file B mocks `Invoke-CommandLine` but doesn't mock a transitive dependency like
+`Stop-WslDistro` (which calls `Test-WslDistroRunning` → `Invoke-CommandLine`), the leaked
+real function may bypass the mock and hit the actual system.
 
 ## BeforeEach/AfterEach Pattern
 

--- a/.claude/skills/ps-wrapper-creator/SKILL.md
+++ b/.claude/skills/ps-wrapper-creator/SKILL.md
@@ -13,7 +13,7 @@ Executable PowerShell scripts should have a .bat wrapper in the same directory.
 
 ### Benefits
 
-- Users can run `script-name` instead of `pwsh -File path/to/script-name.ps1`
+- Users can run `script-name` instead of `powershell -File path/to/script-name.ps1`
 - Batch wrapper handles PowerShell execution policy automatically
 - Arguments are passed through automatically via `%*`
 - Consistent user experience across all executable scripts
@@ -23,13 +23,13 @@ Executable PowerShell scripts should have a .bat wrapper in the same directory.
 
 ```batch
 @echo off
-pwsh -ExecutionPolicy Bypass -File "%~dp0script-name.ps1" %*
+powershell -ExecutionPolicy Bypass -File "%~dp0script-name.ps1" %*
 ```
 
 ### Template Breakdown
 
 - `@echo off` - Suppress command echoing
-- `pwsh` - Use PowerShell 7.x (use `powershell` for 5.1 only)
+- `powershell` - Use Windows PowerShell 5.1 (inbox on all Windows 10+, ensures bootstrapping works)
 - `-ExecutionPolicy Bypass` - Run without policy restrictions
 - `-File` - Execute script file
 - `"%~dp0script-name.ps1"` - Path to PS1 file in same directory
@@ -54,37 +54,18 @@ tools/wsl-manager/
 Wrapper content:
 ```batch
 @echo off
-pwsh -ExecutionPolicy Bypass -File "%~dp0wsl-manager.ps1" %*
+powershell -ExecutionPolicy Bypass -File "%~dp0wsl-manager.ps1" %*
 ```
 
-## PowerShell 5.1 vs 7.x
+## Why `powershell` instead of `pwsh`?
 
-### For PowerShell 7.x Scripts
+All batch wrappers **must** use `powershell` (Windows PowerShell 5.1), not `pwsh` (PowerShell 7):
 
-```batch
-@echo off
-pwsh -ExecutionPolicy Bypass -File "%~dp0script-name.ps1" %*
-```
-
-### For PowerShell 5.1 Only Scripts
-
-```batch
-@echo off
-powershell -ExecutionPolicy Bypass -File "%~dp0script-name.ps1" %*
-```
-
-### For Compatible Scripts (Recommended)
-
-Use `pwsh` by default (most users have it via Scoop), with fallback documentation:
-
-```batch
-@echo off
-pwsh -ExecutionPolicy Bypass -File "%~dp0script-name.ps1" %*
-```
-
-If pwsh is not available, user can:
-1. Install PowerShell 7: `scoop install pwsh`
-2. Or modify wrapper to use `powershell` instead
+- This project targets **PowerShell 5.1+** (see `development-principles.md`)
+- PowerShell 5.1 is inbox on all Windows 10+ machines — no install required
+- PowerShell 7 (`pwsh`) is installed via Scoop, which is itself bootstrapped by these scripts
+- Using `pwsh` in wrappers creates a chicken-and-egg problem on fresh machines
+- All scripts must use only 5.1-compatible syntax, so they work under both versions
 
 ## Automated Wrapper Creation
 
@@ -98,8 +79,8 @@ function New-BatWrapper {
         [string]$ScriptPath,
         
         [Parameter(Mandatory = $false)]
-        [ValidateSet("pwsh", "powershell")]
-        [string]$PowerShellVersion = "pwsh"
+        [ValidateSet("powershell", "pwsh")]
+        [string]$PowerShellVersion = "powershell"
     )
     
     # Validate script exists
@@ -191,7 +172,7 @@ New-BatWrappersForDirectory -Directory ".\tools\wsl-manager"
 script-name arg1 arg2
 
 # Should be equivalent to:
-pwsh -File script-name.ps1 arg1 arg2
+powershell -File script-name.ps1 arg1 arg2
 ```
 
 ### Test from Keypirinha
@@ -210,7 +191,7 @@ See `assets/wrapper-template.bat` for a template file.
 
 1. **Same directory** - Wrapper must be in same directory as .ps1 file
 2. **Same name** - Wrapper must have same name as .ps1 file (except extension)
-3. **Use pwsh** - Prefer PowerShell 7.x for new scripts
+3. **Use powershell** - Use Windows PowerShell 5.1 for compatibility (see development-principles.md)
 4. **Pass arguments** - Always include `%*` to pass arguments
 5. **Bypass execution policy** - Use `-ExecutionPolicy Bypass`
 6. **Test** - Verify wrapper works before committing

--- a/.claude/skills/ps-wrapper-creator/assets/wrapper-template.bat
+++ b/.claude/skills/ps-wrapper-creator/assets/wrapper-template.bat
@@ -1,2 +1,2 @@
 @echo off
-pwsh -ExecutionPolicy Bypass -File "%~dp0script-name.ps1" %*
+powershell -ExecutionPolicy Bypass -File "%~dp0script-name.ps1" %*

--- a/.claude/skills/refinement/references/backlog-format.md
+++ b/.claude/skills/refinement/references/backlog-format.md
@@ -146,7 +146,7 @@ File: `done/prefix-001.md`
 ```markdown
 # [HSH-001] ✅ COMPLETED - Brief descriptive title
 
-**Status**: **Completed** (YYYY-MM-DD) | **Branch**: `branch-name`
+**Status**: Completed (YYYY-MM-DD)
 **Priority**: Medium
 **Component**: `path/to/affected/file.ext`
 
@@ -192,4 +192,4 @@ When moving items:
 1. Move the item file between folders: `git mv todo/prefix-015.md in_progress/prefix-015.md`
 2. Update the `**Status**` field inside the file
 3. Update the Table of Contents links in `index.md` (move the link to the correct section, update the relative path)
-4. For completed items: add date, branch name, and `✅ COMPLETED -` prefix to heading
+4. For completed items: add date and `✅ COMPLETED -` prefix to heading

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,11 @@ tools/wsl-manager/
 - Arguments are passed through automatically via `%*`
 - Consistent user experience across all executable scripts
 
+## Documentation Hierarchy
+
+- Each tool gets one doc (e.g., `wsl-manager.md`). Supported workflows like DevContainer setup belong as a section within the tool's doc, not as standalone guides.
+- **Don't let a feature outgrow its tool** — DevContainer support is a feature of WSL Manager, not a separate product.
+
 ## Coding Guidelines
 
 - TDD
@@ -63,6 +68,12 @@ tools/wsl-manager/
 - test fixtures
 - mocking external dependencies
 - conventional commits
+
+### Linting Suppression Policy
+
+**Never suppress these rules — fix the code instead:**
+- `PSReviewUnusedParameter` — make the parameter actually used, or remove it.
+- `PSUseSingularNouns` — rename the function to use a singular noun (PowerShell convention: `Verb-SingularNoun`).
 
 ### No Speculative Alternatives
 
@@ -429,19 +440,22 @@ The project uses a `.bootstrap` system (see `.bootstrap/` directory):
 
 **Context**: This project uses GitHub Actions CI. The `develop` branch is always green.
 
-**Guideline**: When working on a feature branch, ANY test failures are caused by changes on that branch.
+**CRITICAL: There are no pre-existing test failures. Ever.** CI ensures `develop` is always green. Feature branches are created from `develop`. Therefore, any failure on a feature branch was introduced by that branch — no exceptions.
 
-**Reasoning**:
-- CI ensures `develop` is always green
-- Feature branches are created from `develop`
-- Therefore, failures = something introduced on the feature branch
+**You MUST NOT:**
+- Dismiss failures as "pre-existing" or "unrelated to my changes"
+- Skip failing tests or proceed to commit with uninvestigated failures
+- Assume that tests in files you didn't directly modify can't be affected by your changes
 
-**Workflow when encountering test failures**:
-1. **NEVER assume failures are pre-existing**
-2. Check `git diff develop..HEAD` to see all changes on the branch
-3. Analyze if ANY change (even cosmetic ones like string formatting) could affect tests
-4. If uncertain, use `git bisect` to identify the breaking commit
-5. Fix the issue before proceeding
+**You MUST:**
+- Investigate every failure — even in files you didn't touch
+- If uncertain whether your changes caused it, flag it to the user — never silently skip
+- Fix the issue before proceeding
+
+**Investigation steps**:
+1. `git diff develop..HEAD` — review ALL changes on the branch
+2. Analyze if ANY change (even cosmetic ones like string formatting) could affect tests
+3. If uncertain, use `git bisect` to identify the breaking commit
 
 **Anti-pattern**:
 ```bash
@@ -481,6 +495,20 @@ Using `shell: ${{ matrix.shell }}` will fail. Instead, use `shell: cmd` and invo
 ```
 
 **For multi-line PowerShell** (e.g., the remote install step), use a hardcoded shell (`shell: powershell` or `shell: pwsh`) since multi-line code cannot be wrapped in a single `-Command` string through cmd.
+
+#### Backlog Conventions
+
+- **No commit hashes in backlog entries** — the backlog file is part of the commit itself, so hashes are circular and go stale after squash/rebase.
+- **No unrelated files in feature commits** — keep commits scoped to the feature; unrelated additions get their own commit.
+- **Always update backlog with every commit** — move item to IN PROGRESS at start, check off acceptance criteria as they're completed, move to DONE when finished. Backlog updates go in the same commit as the code.
+
+#### Communication
+
+- **Problem statements are not build directives** — when the user describes a problem or goal, ask what approach they want before implementing. Especially for changes to shared infrastructure (hooks, CI, config) that affect all contributors.
+
+#### Windows/Git Bash Pitfalls
+
+- **NUL vs /dev/null**: On Windows under Git Bash/MSYS2, redirecting to `NUL` creates a literal file named `nul`. Always use `/dev/null` in Bash contexts.
 
 #### When to Use EnterPlanMode (MANDATORY)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,6 +396,23 @@ This function exists solely to prevent interactive prompts (`Read-Host`) in CI/t
 environments. Mocking it to `$false` defeats its purpose. Tests that need to exercise
 non-interactive code paths must provide explicit parameters that bypass the guard.
 
+**Cross-file test isolation (MANDATORY):**
+Pester runs all test files in the same PowerShell process. Functions loaded via dot-sourcing
+persist across files and cause flaky, order-dependent failures. Every test file that
+dot-sources a library **must** use `Start-SutIsolation`/`Stop-SutIsolation` from `test/bin/lib/TestIsolation.ps1`:
+
+```powershell
+BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
+    . "$PSScriptRoot\module.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
+}
+```
+
 See `lib/AGENTS.md` for additional testing guidelines
 
 ### Project-Specific Considerations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,10 +391,10 @@ powershell -File ".\test\bin\testrunner.ps1"
 - Test both success and failure paths
 - Ensure tests pass on both PowerShell 5.1 and 7.x
 
-**Never mock `Test-RunningInCIorTestEnvironment`.**
-This function exists solely to prevent interactive prompts (`Read-Host`) in CI/test
-environments. Mocking it to `$false` defeats its purpose. Tests that need to exercise
-non-interactive code paths must provide explicit parameters that bypass the guard.
+**Never mock `Test-RunningInCIorTestEnvironment` in integration tests.**
+This function exists to prevent interactive prompts (`Read-Host`) in CI/test environments.
+Mocking it to `$false` in integration tests would trigger real `Read-Host` calls that hang CI.
+In **unit tests**, mocking it is allowed and encouraged to cover both CI and interactive code paths.
 
 **Cross-file test isolation (MANDATORY):**
 Pester runs all test files in the same PowerShell process. Functions loaded via dot-sourcing

--- a/bin/install.Tests.ps1
+++ b/bin/install.Tests.ps1
@@ -6,7 +6,13 @@
 #>
 
 BeforeAll {
+    . "$PSScriptRoot\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     $script:installScript = Join-Path $PSScriptRoot 'install.ps1'
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe 'Install-Scoop' {

--- a/docs/backlog/done/bug-001.md
+++ b/docs/backlog/done/bug-001.md
@@ -1,6 +1,6 @@
 # [BUG-001] ✅ COMPLETED - WSL Manager fails when no distributions are installed
 
-**Status**: **Completed** (2026-01-29)
+**Status**: Completed (2026-01-29)
 **Priority**: High
 **Component**: `tools/pslib/wsl/lib/core.ps1`
 

--- a/docs/backlog/done/bug-002.md
+++ b/docs/backlog/done/bug-002.md
@@ -1,6 +1,6 @@
 # [BUG-002] ✅ COMPLETED - VS Code WSL Interop Interference Fixed
 
-**Status**: **Completed** (2026-02-03) | **Branch**: `feature/wsl-devcontainer-prep`
+**Status**: Completed (2026-02-03)
 **Priority**: High
 **Component**: `tools/pslib/wsl/scripts/install-docker.sh`, `tools/pslib/wsl/lib/docker.ps1`
 

--- a/docs/backlog/done/bug-003.md
+++ b/docs/backlog/done/bug-003.md
@@ -1,6 +1,6 @@
 # [BUG-003] ✅ COMPLETED - UTF-8 BOM in integration test bash scripts causes shebang error
 
-**Status**: **Completed** (2026-02-20) | **Branch**: `feature/feat-002-podman-wsl`
+**Status**: Completed (2026-02-20)
 **Priority**: Low
 **Component**: `tools/pslib/wsl/wsl-manager.docker.Integration.Tests.ps1`
 

--- a/docs/backlog/done/bug-004.md
+++ b/docs/backlog/done/bug-004.md
@@ -1,6 +1,6 @@
 # [BUG-004] ✅ COMPLETED - Flaky integration test for terminating already-stopped distribution
 
-**Status**: **Completed** (2026-02-22) | **Branch**: `refinement`
+**Status**: Completed (2026-02-22)
 **Priority**: Low
 **Component**: `tools/pslib/wsl/wsl-manager.docker.Integration.Tests.ps1`
 

--- a/docs/backlog/done/chore-001.md
+++ b/docs/backlog/done/chore-001.md
@@ -1,6 +1,6 @@
 # [CHORE-001] ✅ COMPLETED - Move reusable skills to global ~/.claude/skills
 
-**Status**: **Completed** (2026-02-22) | **Branch**: `refinement`
+**Status**: Completed (2026-02-22)
 **Priority**: Low
 **Component**: `.claude/skills/`
 

--- a/docs/backlog/done/ci-001.md
+++ b/docs/backlog/done/ci-001.md
@@ -1,6 +1,6 @@
 # [CI-001] ✅ COMPLETED - Upload code coverage and test results to Codecov
 
-**Status**: **Completed** (2026-02-21) | **Branch**: `feature/ci-codecov-upload`
+**Status**: Completed (2026-02-21)
 **Priority**: Low
 **Component**: `.github/workflows/test.yml`
 

--- a/docs/backlog/done/ci-002.md
+++ b/docs/backlog/done/ci-002.md
@@ -1,6 +1,6 @@
 # [CI-002] ✅ COMPLETED - Normalize JUnit XML paths for Codecov Test Analytics
 
-**Status**: **Completed** (2026-02-21) | **Branch**: `feature/ci-001-normalize-junit-xml`
+**Status**: Completed (2026-02-21)
 **Priority**: Low
 **Component**: `test/bin/testrunner.ps1`, `test/bin/testrunner.Tests.ps1` (new)
 

--- a/docs/backlog/done/ci-003.md
+++ b/docs/backlog/done/ci-003.md
@@ -1,6 +1,6 @@
 # [CI-003] ✅ COMPLETED - Normalize JaCoCo XML paths for Codecov coverage
 
-**Status**: **Completed** (2026-02-21) | **Branch**: `feature/ci-003-normalize-jacoco-xml`
+**Status**: Completed (2026-02-21)
 **Priority**: Low
 **Component**: `test/bin/testrunner.ps1`, `test/bin/testrunner.Tests.ps1`
 

--- a/docs/backlog/done/feat-001.md
+++ b/docs/backlog/done/feat-001.md
@@ -1,6 +1,6 @@
 # [FEAT-001] ✅ COMPLETED - DevContainer Prep → Docker Prerequisites
 
-**Status**: **Completed** (2026-02-02) | **Branch**: `feature/wsl-devcontainer-prep` → PR #18
+**Status**: Completed (2026-02-02)
 **Original**: Completed (2026-01-30) | **Refactored**: (2026-01-31) | **Documentation**: (2026-02-02)
 **Priority**: Medium
 **Component**: `tools/pslib/wsl/lib/docker.ps1`, `tools/pslib/wsl/scripts/install-docker.sh`

--- a/docs/backlog/done/feat-002.md
+++ b/docs/backlog/done/feat-002.md
@@ -1,6 +1,6 @@
 # [FEAT-002] ✅ COMPLETED - Set up Podman as Docker alternative in WSL
 
-**Status**: **Completed** (2026-02-24) | **Branch**: `feature/feat-002-podman-wsl`
+**Status**: Completed (2026-02-24)
 **Priority**: Medium
 **Component**: `tools/pslib/wsl/lib/podman.ps1` (new), `tools/pslib/wsl/scripts/install-podman.sh` (new), `tools/pslib/wsl/wsl-manager.ps1`
 **Related**: FEAT-001, Dev Container workflow

--- a/docs/backlog/done/feat-003.md
+++ b/docs/backlog/done/feat-003.md
@@ -1,6 +1,6 @@
 # [FEAT-003] ✅ COMPLETED - Add Flow Launcher as Standalone Optional Tool
 
-**Status**: **Completed** (2026-02-10) | **Branch**: `feature/feat-003-flow-launcher`
+**Status**: Completed (2026-02-10)
 **Priority**: Medium
 **Component**: `tools/flow-launcher/`
 

--- a/docs/backlog/done/feat-004.md
+++ b/docs/backlog/done/feat-004.md
@@ -1,6 +1,6 @@
 # [FEAT-004] ✅ COMPLETED - Replace Bootstrap with Self-Contained install.ps1
 
-**Status**: **Completed** (2026-02-11) | **Branch**: `feature/feat-004-self-contained-install`
+**Status**: Completed (2026-02-11)
 **Priority**: Medium
 **Component**: `bin/install.ps1`, `scoop_mandatory.json`, `scoop_optional.json`
 **Type**: Feature / Refactoring

--- a/docs/backlog/done/refact-001.md
+++ b/docs/backlog/done/refact-001.md
@@ -1,6 +1,6 @@
 # [REFACT-001] ✅ COMPLETED - Add `-Selection` parameter to `Invoke-UpdateDistro` and `Invoke-RemoveDistro`
 
-**Status**: **Completed** (2026-02-20) | **Branch**: `feature/feat-002-podman-wsl`
+**Status**: Completed (2026-02-20)
 **Priority**: Medium
 **Component**: `tools/pslib/wsl/wsl-manager.ps1`
 **Blocks**: REFACT-003

--- a/docs/backlog/done/refact-002.md
+++ b/docs/backlog/done/refact-002.md
@@ -1,6 +1,6 @@
 # [REFACT-002] ✅ COMPLETED - Fix `Invoke-SetupUser` CI guard scope and add explicit parameters
 
-**Status**: **Completed** (2026-02-20) | **Branch**: `feature/feat-002-podman-wsl`
+**Status**: Completed (2026-02-20)
 **Priority**: Medium
 **Component**: `tools/pslib/wsl/wsl-manager.ps1`
 **Blocks**: REFACT-003

--- a/docs/backlog/done/refact-003.md
+++ b/docs/backlog/done/refact-003.md
@@ -1,6 +1,6 @@
 # [REFACT-003] ✅ COMPLETED - Refactor wsl-manager integration tests to call wsl-manager functions
 
-**Status**: **Completed** (2026-02-21) | **Branch**: `feature/refact-001-002-003`
+**Status**: Completed (2026-02-21)
 **Priority**: Medium
 **Component**: `tools/pslib/wsl/wsl-manager.docker.Integration.Tests.ps1`
 

--- a/docs/backlog/done/refact-004.md
+++ b/docs/backlog/done/refact-004.md
@@ -1,6 +1,6 @@
 # [REFACT-004] ✅ COMPLETED - Remove redundant `Test-WslInstalled` guard checks (DRY)
 
-**Status**: **Completed** (2026-02-24) | **Branch**: `feature/feat-002-podman-wsl`
+**Status**: Completed (2026-02-24)
 **Priority**: Medium
 **Component**: `tools/pslib/wsl/` (8 source files, 8 test files)
 

--- a/docs/backlog/done/refact-005.md
+++ b/docs/backlog/done/refact-005.md
@@ -1,6 +1,6 @@
 # [REFACT-005] ✅ COMPLETED - Extract `Assert-WslDistroExists` guard to replace inline distro validation (DRY)
 
-**Status**: **Completed** (2026-02-24) | **Branch**: `feature/feat-002-podman-wsl`
+**Status**: Completed (2026-02-24)
 **Priority**: Medium
 **Component**: `tools/pslib/wsl/` (7 source files, 7 test files)
 **Related**: REFACT-004 (same pattern — entry-point guard extraction)

--- a/docs/backlog/done/sc-003.md
+++ b/docs/backlog/done/sc-003.md
@@ -1,6 +1,6 @@
 # [SC-003] ✅ COMPLETED - Stop action functions from reprinting distro table in interactive mode
 
-**Status**: **Completed** (2026-03-06)
+**Status**: Completed (2026-03-06)
 **Priority**: Medium
 **Component**: `tools/pslib/wsl/wsl-manager.ps1`
 **Depends on**: SC-005

--- a/docs/backlog/done/sc-004.md
+++ b/docs/backlog/done/sc-004.md
@@ -1,6 +1,6 @@
 # [SC-004] ✅ COMPLETED - Consolidate documentation and make all docs reachable from README
 
-**Status**: **Completed** (2026-03-03) | **Branch**: `refinement`
+**Status**: Completed (2026-03-03)
 **Priority**: Medium
 **Component**: `README.md`, `docs/`
 

--- a/docs/backlog/done/sc-007.md
+++ b/docs/backlog/done/sc-007.md
@@ -1,6 +1,6 @@
 # [SC-007] ✅ COMPLETED - Add `setup-proxy` action to wsl-manager with automatic proxy detection
 
-**Status**: **Completed** (2026-03-02)
+**Status**: Completed (2026-03-02)
 **Priority**: Urgent
 **Component**: `tools/proxy/setProxy.ps1` (existing, rename guard), `tools/pslib/wsl/lib/proxy.ps1` (new), `tools/pslib/wsl/scripts/setup-proxy.sh` (new), `tools/pslib/wsl/wsl-manager.ps1`
 **Related**: FEAT-002 (Podman setup — `.bashrc` pattern), FEAT-001 (Docker setup)

--- a/docs/backlog/done/sc-008.md
+++ b/docs/backlog/done/sc-008.md
@@ -1,6 +1,6 @@
 # [SC-008] ✅ COMPLETED - Split backlog into index and per-item files
 
-**Status**: **Completed** (2026-03-02) | **Branch**: `refinement`
+**Status**: Completed (2026-03-02)
 **Priority**: Low
 **Component**: `docs/backlog.md` → `docs/backlog/`
 

--- a/docs/backlog/done/sc-009.md
+++ b/docs/backlog/done/sc-009.md
@@ -1,6 +1,6 @@
 # [SC-009] ✅ COMPLETED - PowerShell Lint Guard (skill + pre-commit hook)
 
-**Status**: **Completed** (2026-03-02)
+**Status**: Completed (2026-03-02)
 **Priority**: High
 **Component**: `.claude/skills/powershell-dev/SKILL.md`, `tools/githooks/pre-commit`, `tools/githooks/install-hooks.ps1`
 

--- a/docs/backlog/done/sc-011.md
+++ b/docs/backlog/done/sc-011.md
@@ -1,6 +1,6 @@
 # [SC-011] WSL Manager: mask credentials and auto-terminate after install
 
-**Status**: Done
+**Status**: Completed (2026-03-04)
 **Priority**: High
 **Component**: `tools/pslib/wsl/wsl-manager.ps1`
 

--- a/docs/backlog/done/sc-012.md
+++ b/docs/backlog/done/sc-012.md
@@ -1,6 +1,6 @@
 # [SC-012] ✅ COMPLETED - Stop-WslDistro: verify termination with retry
 
-**Status**: **Completed** (2026-03-04)
+**Status**: Completed (2026-03-04)
 **Priority**: High
 **Component**: `tools/pslib/wsl/lib/core.ps1`
 

--- a/docs/backlog/done/sc-014.md
+++ b/docs/backlog/done/sc-014.md
@@ -1,6 +1,6 @@
 # [SC-014] ✅ COMPLETED - setup-user CLI does not accept -Username and -Password parameters
 
-**Status**: **Completed** (2026-03-05) | **Branch**: `feature/sc-014`
+**Status**: Completed (2026-03-05)
 **Priority**: High
 **Component**: `tools/pslib/wsl/wsl-manager.ps1`
 

--- a/docs/backlog/done/sc-015.md
+++ b/docs/backlog/done/sc-015.md
@@ -1,6 +1,6 @@
-# [SC-015] Reorganize project structure: separate tools from libraries
+# [SC-015] ✅ COMPLETED - Reorganize project structure: separate tools from libraries
 
-**Status**: In Progress
+**Status**: **Completed** (2026-03-15)
 **Priority**: Medium
 **Component**: `lib/`, `tools/wsl-manager/`
 

--- a/docs/backlog/done/sc-015.md
+++ b/docs/backlog/done/sc-015.md
@@ -1,6 +1,6 @@
 # [SC-015] ✅ COMPLETED - Reorganize project structure: separate tools from libraries
 
-**Status**: **Completed** (2026-03-15)
+**Status**: Completed (2026-03-15)
 **Priority**: Medium
 **Component**: `lib/`, `tools/wsl-manager/`
 

--- a/docs/backlog/done/sc-018.md
+++ b/docs/backlog/done/sc-018.md
@@ -1,6 +1,6 @@
 # [SC-018] Install Claude GitHub App and remove legacy workflows
 
-**Status**: Done
+**Status**: Completed (2026-03-06)
 **Priority**: High
 **Component**: `.github/workflows/`
 

--- a/docs/backlog/done/sc-019.md
+++ b/docs/backlog/done/sc-019.md
@@ -1,6 +1,6 @@
 # [SC-019] ✅ COMPLETED - Allow model selection via @claude trigger phrase
 
-**Status**: **Completed** (2026-03-07)
+**Status**: Completed (2026-03-07)
 **Priority**: Medium
 **Component**: `.github/workflows/claude.yml`
 

--- a/docs/backlog/done/sc-021.md
+++ b/docs/backlog/done/sc-021.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Completed** (2026-03-11)
+**Status**: Completed (2026-03-11)
 
 ## Description
 

--- a/docs/backlog/done/sc-022.md
+++ b/docs/backlog/done/sc-022.md
@@ -1,0 +1,51 @@
+# [SC-022] ✅ COMPLETED - Make generic skills reusable across repositories
+
+**Status**: Completed (2026-03-15)
+**Priority**: Medium
+**Component**: `.claude/skills/`
+
+**Summary**:
+As a developer working across multiple repositories, I want generic workflow skills (commit-helper, tdd-workflow, refinement, retrospective) to be reusable without modification, and language-specific skills (PowerShell) to be reusable across projects of the same language.
+
+**Description**:
+Currently, generic workflow skills embed project-specific test commands and language-specific references (e.g., PowerShell file names, dot-sourcing). This ties them to a single project and prevents reuse.
+
+The solution is a two-layer skill architecture with a naming convention:
+
+1. **Generic skills** (commit-helper, tdd-workflow, refinement, retrospective) define the *workflow* — when to test, commit conventions, TDD cycle — without any language-specific content. They delegate test execution to the project's test execution skill.
+2. **Language-specific skills** are prefixed with the language name (e.g., `powershell-*`) so they can be reused across projects of the same language.
+3. **Project-specific skills** (keypirinha-shortcuts, scoop-integration) remain project-local.
+
+### Discovery mechanism
+
+Generic skills say "use the project's test execution skill" without hardcoding a skill name. Claude discovers the correct skill from the available skill list in the system prompt.
+
+### Naming convention
+
+| Category | Prefix | Example | Reuse scope |
+|---|---|---|---|
+| Generic workflow | (none) | `commit-helper`, `tdd-workflow` | Any repo |
+| Language-specific | language name | `powershell-test-exec`, `powershell-dev` | Repos using that language |
+| Project-specific | (varies) | `keypirinha-shortcuts`, `scoop-integration` | This repo only |
+
+### Integration test detection
+
+Generic skills detect integration tests by case-insensitive matching of "integration" in the file path relative to the project root (e.g., `test/integration/`, `tests/foo.integration.test.js`, `lib/bar.Integration.Tests.ps1`).
+
+### Skills to refactor
+
+- `commit-helper` — remove all language-specific content, delegate test execution generically ✅
+- `tdd-workflow` — remove all language-specific content, delegate test execution generically ✅
+- `test-exec` → `powershell-test-exec` — rename to follow language-prefix convention
+- `ps-wrapper-creator` → `powershell-wrapper-creator` — rename to follow language-prefix convention
+- `commit-helper`, `tdd-workflow` — replace hardcoded `test-exec` references with generic "project's test execution skill"
+- `powershell-dev` — update references from `test-exec` to `powershell-test-exec`
+
+**Acceptance Criteria**:
+- [x] `commit-helper` is language-agnostic — no hardcoded commands, no language-specific file names or patterns
+- [x] `tdd-workflow` is language-agnostic — no hardcoded commands, no language-specific code examples
+- [x] Integration test detection uses case-insensitive match of "integration" in the file path
+- [x] All PowerShell-specific skills are prefixed with `powershell-` (`powershell-test-exec`, `powershell-wrapper-creator`, `powershell-dev`)
+- [x] Generic skills do not hardcode a test execution skill name — they say "the project's test execution skill" and rely on Claude to discover it
+- [x] `powershell-dev` references updated to use `powershell-test-exec`
+- [x] Generic skills (commit-helper, tdd-workflow) can be dropped into any repo and work with that repo's test execution skill

--- a/docs/backlog/done/sc-024.md
+++ b/docs/backlog/done/sc-024.md
@@ -1,0 +1,54 @@
+# [SC-024] ✅ COMPLETED - Maintain PowerShell 5.1 compatibility and fix batch wrapper violations
+
+**Status**: Completed (2026-03-18)
+**Priority**: Medium
+**Component**: Project-wide
+
+**Summary**:
+As a user bootstrapping a fresh Windows machine, I need all scripts to run under PowerShell 5.1 (the inbox Windows PowerShell) so that I can use this toolkit without installing PowerShell 7 first.
+
+**Description**:
+
+### Decision: Keep PowerShell 5.1 as the minimum version
+
+After researching the PowerShell community's stance and Microsoft's support lifecycle, the decision is to **keep PowerShell 5.1 as the compatibility floor**. Key reasons:
+
+#### 1. Bootstrapping requires inbox PowerShell
+This is a setup/bootstrapping toolkit. PowerShell 7 (`pwsh`) is installed *via* Scoop, which is itself installed by these scripts. Requiring PS 7 to run the installer that installs PS 7 is a chicken-and-egg problem. The batch wrappers must invoke `powershell.exe` (5.1), not `pwsh.exe` (7+).
+
+#### 2. PowerShell 5.1 has no independent EOL
+PS 5.1's lifecycle is tied to the Windows versions that ship it. Windows Server 2022 (ships with PS 5.1) is supported until October 2031. Windows 11 24H2 ships with PS 5.1 as well. It is not going away any time soon.
+
+#### 3. PS 7 is not shipped inbox with Windows
+Despite an [active community discussion](https://github.com/PowerShell/PowerShell/discussions/24340), Microsoft has not shipped PS 7 as a built-in Windows component. Users must install it separately.
+
+#### 4. Community consensus supports dual compatibility
+The PowerShell community broadly recommends supporting both 5.1 and 7.x when targeting Windows environments, especially for tooling that runs on machines where PS 7 may not be present. See:
+- [Microsoft: Differences between PS 5.1 and 7.x](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/differences-from-windows-powershell?view=powershell-7.5)
+- [PowerShell Support Lifecycle](https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.5)
+- [ScriptRunner: PowerShell 7 vs 5.1](https://www.scriptrunner.com/blog-admin-architect/switching-to-powershell-7)
+
+#### 5. Low maintenance cost
+The codebase is already 5.1-compatible. The only version-specific handling needed so far is `$PSStyle` detection in `testrunner.ps1` and PSCustomObject output format in SC-006.
+
+### Batch wrapper violations
+
+Several `.bat` wrappers currently use `pwsh` instead of `powershell`, which breaks on machines where PowerShell 7 is not yet installed:
+
+| File | Current | Required |
+|------|---------|----------|
+| `.claude/skills/powershell-wrapper-creator/assets/wrapper-template.bat` | `pwsh` | `powershell` |
+| `tools/github-copilot/install-github-copilot.bat` | `pwsh` | `powershell` |
+| `tools/flow-launcher/configure-program-plugin.bat` | `pwsh` | `powershell` |
+| `tools/flow-launcher/install-flow-launcher.bat` | `pwsh` | `powershell` |
+| `tools/claude-code/install-claude-code.bat` | `pwsh` | `powershell` |
+
+The wrapper template is the root cause — it generates new wrappers with `pwsh`. Fixing the template prevents future violations.
+
+**Acceptance Criteria**:
+- [x] All `.bat` wrappers invoke `powershell -ExecutionPolicy Bypass`, not `pwsh`
+- [x] The wrapper template in `.claude/skills/powershell-wrapper-creator/assets/wrapper-template.bat` uses `powershell`
+- [x] No `.bat` file in the repository references `pwsh`
+- [x] All PowerShell scripts use only 5.1-compatible syntax (no PS 6.0+ exclusive features)
+- [x] CI matrix continues to test on both PowerShell 5.1 and 7.x
+- [x] `development-principles.md` remains the canonical reference for the PS 5.1 compatibility rule

--- a/docs/backlog/in_progress/sc-001.md
+++ b/docs/backlog/in_progress/sc-001.md
@@ -1,6 +1,6 @@
 # [SC-001] Backlog refinement
 
-**Status**: **In Progress**
+**Status**: In Progress
 **Priority**: —
 
 **Description**:

--- a/docs/backlog/index.md
+++ b/docs/backlog/index.md
@@ -20,6 +20,7 @@
 - [SC-017 — Auto-terminate distros instead of prompting the user](todo/sc-017.md)
 - [SC-020 — Import and export WSL distributions to/from files](todo/sc-020.md)
 - [SC-022 — Make generic skills reusable across repositories](todo/sc-022.md)
+- [SC-023 — Per-file code coverage in testrunner.ps1](todo/sc-023.md)
 
 ### Done
 - [SC-024 — Maintain PowerShell 5.1 compatibility and fix batch wrapper violations](done/sc-024.md)

--- a/docs/backlog/index.md
+++ b/docs/backlog/index.md
@@ -22,6 +22,7 @@
 - [SC-022 — Make generic skills reusable across repositories](todo/sc-022.md)
 
 ### Done
+- [SC-024 — Maintain PowerShell 5.1 compatibility and fix batch wrapper violations](done/sc-024.md)
 - [SC-015 — Reorganize project structure: separate tools from libraries](done/sc-015.md)
 - [SC-021 — Apply default WSL global settings (.wslconfig) via wsl-manager](done/sc-021.md)
 - [SC-005 — Refactor WSL Manager command dispatch (DRY)](done/sc-005.md)
@@ -68,7 +69,7 @@
 
 1. **Verify acceptance criteria** — all `[ ]` must be `[x]`. Do NOT close with unchecked items.
 2. **Update the heading** — add `✅ COMPLETED` (e.g., `# [SC-004] ✅ COMPLETED - …`)
-3. **Update the Status field** — change to `**Completed** (YYYY-MM-DD)`
+3. **Update the Status field** — change to `**Status**: Completed (YYYY-MM-DD)`
 4. **Update this index** — move the entry from its current section to **Done**, change path from `in_progress/` (or `todo/`) to `done/`
 5. **Move the file** — `git mv docs/backlog/in_progress/sc-004.md docs/backlog/done/sc-004.md`
 

--- a/docs/backlog/index.md
+++ b/docs/backlog/index.md
@@ -12,7 +12,6 @@
 
 ### In Progress
 - [SC-001 — Backlog refinement](in_progress/sc-001.md)
-- [SC-015 — Reorganize project structure: separate tools from libraries](in_progress/sc-015.md)
 
 ### TODO
 - [SC-006 — Scoop Update Helper Script](todo/sc-006.md)
@@ -20,8 +19,10 @@
 - [SC-016 — Improve interactive menu UX: instant key input and Esc-to-menu](todo/sc-016.md)
 - [SC-017 — Auto-terminate distros instead of prompting the user](todo/sc-017.md)
 - [SC-020 — Import and export WSL distributions to/from files](todo/sc-020.md)
+- [SC-022 — Make generic skills reusable across repositories](todo/sc-022.md)
 
 ### Done
+- [SC-015 — Reorganize project structure: separate tools from libraries](done/sc-015.md)
 - [SC-021 — Apply default WSL global settings (.wslconfig) via wsl-manager](done/sc-021.md)
 - [SC-005 — Refactor WSL Manager command dispatch (DRY)](done/sc-005.md)
 - [SC-019 — Allow model selection via @claude trigger phrase](done/sc-019.md)

--- a/docs/backlog/todo/sc-023.md
+++ b/docs/backlog/todo/sc-023.md
@@ -1,0 +1,45 @@
+# [SC-023] Per-file code coverage in testrunner.ps1
+
+**Status**: Open
+**Priority**: Low
+**Component**: `test/bin/testrunner.ps1`
+
+**Summary**:
+As a developer, I want to see code coverage broken down per source file so that I can quickly identify which files have low coverage without parsing the JaCoCo XML manually.
+
+**Description**:
+The current `-Coverage` flag reports a single aggregate percentage across all 19 source files (e.g. "Coverage: 84.4%"). When running tests for a specific file (`-TestPath lib/scoop/scoop.Tests.ps1`), the coverage is still measured against all source files, producing misleading numbers (e.g. 5%).
+
+### Proposed enhancements
+
+#### 1. Per-file coverage table
+After the aggregate summary, print a per-file breakdown sorted by coverage ascending (worst first):
+
+```
+Code Coverage by File:
+  File                        Coverage
+  ----                        --------
+  lib/wsl/proxy.ps1           62.3%
+  lib/wsl/install.ps1         71.8%
+  lib/scoop/scoop.ps1         89.2%
+  lib/wsl/ops.ps1             91.4%
+  ...
+  Overall                     84.4%
+```
+
+#### 2. Scoped coverage for `-TestPath`
+When `-TestPath` is specified, only measure coverage for the corresponding source files (using the existing `*.Tests.ps1` -> `*.ps1` mapping) instead of all project source files. This makes per-file test runs report meaningful coverage.
+
+### Technical notes
+- Pester's `$testResult.CodeCoverage` already provides `CommandsExecuted` and `CommandsMissed` with `File` properties — group by file to compute per-file stats
+- The existing `Get-CoverageSummary` function (lines 126-168) can be extended or a new `Get-CoverageByFile` helper added
+- When `-TestPath` is used, filter `$coveragePaths` to only include source files that correspond to the provided test files (the mapping logic already exists in lines 361-378)
+- Keep the aggregate summary as-is for backwards compatibility
+
+**Acceptance Criteria**:
+- [ ] `testrunner.ps1 -Coverage` prints a per-file coverage table after the aggregate summary
+- [ ] Per-file table is sorted by coverage ascending (lowest first)
+- [ ] `testrunner.ps1 -TestPath "lib/scoop/scoop.Tests.ps1" -Coverage` only measures coverage for `lib/scoop/scoop.ps1`
+- [ ] Aggregate summary remains unchanged for backwards compatibility
+- [ ] JaCoCo XML output is unaffected
+- [ ] Works on both PowerShell 5.1 and 7.x

--- a/lib/scoop/scoop.Integration.Tests.ps1
+++ b/lib/scoop/scoop.Integration.Tests.ps1
@@ -1,0 +1,81 @@
+﻿#Requires -Version 5.1
+
+<#
+.SYNOPSIS
+    Integration tests for Scoop update helper functions in scoop.ps1
+
+.DESCRIPTION
+    Integration tests that verify Get-ScoopUpdatableApp and Invoke-ScoopUpdate
+    work correctly with the real scoop command. The key scenario is that
+    'scoop status' via Invoke-CommandLine does not crash under $ErrorActionPreference = 'Stop'.
+
+    REQUIREMENTS:
+    - Scoop must be installed
+    - Internet connection required
+
+    WARNING: These tests call real scoop commands (status, update) but do NOT update any apps.
+#>
+
+[CmdletBinding()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Integration tests use Write-Host for user feedback')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseBOMForUnicodeEncodedFile', '', Justification = 'UTF-8 without BOM is standard for cross-platform')]
+param()
+
+BeforeDiscovery {
+    $script:skipTests = -not (Get-Command scoop -ErrorAction SilentlyContinue)
+}
+
+BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
+    . "$PSScriptRoot\scoop.ps1"
+
+    # Mock console output to keep test output clean
+    Mock Write-Host {}
+    Mock Write-Status {}
+    Mock Write-Success {}
+    Mock Write-WarningMsg {}
+    Mock Write-ErrorMsg {}
+}
+
+AfterAll {
+    Stop-SutIsolation
+}
+
+Describe 'Get-ScoopUpdatableApp - real scoop status' -Tag "Integration" -Skip:$script:skipTests {
+
+    It 'does not throw when calling scoop status' {
+        { Get-ScoopUpdatableApp } | Should -Not -Throw
+    }
+
+    It 'returns an array with correct shape' {
+        $result = @(Get-ScoopUpdatableApp)
+
+        $result.GetType().IsArray | Should -BeTrue
+        foreach ($app in $result) {
+            $app.Name | Should -Not -BeNullOrEmpty
+            $app.InstalledVersion | Should -Not -BeNullOrEmpty
+            $app.LatestVersion | Should -Not -BeNullOrEmpty
+        }
+
+        # Sanity check: if scoop status reports updates, we should find them
+        $rawStatus = Invoke-CommandLine -CommandLine "scoop status" -StopAtError $false -PrintCommand $false
+        if ($null -ne $rawStatus -and @($rawStatus).Count -gt 0) {
+            $result.Count | Should -BeGreaterThan 0 -Because "scoop status reported updates but Get-ScoopUpdatableApp returned none"
+        }
+    }
+}
+
+Describe 'Invoke-ScoopUpdate - real scoop flow' -Tag "Integration" -Skip:$script:skipTests {
+
+    BeforeAll {
+        # Mock Read-Host to prevent interactive blocking (return 'A' = select all)
+        Mock Read-Host { return 'A' }
+        # Mock Update-ScoopApp so we don't actually update anything
+        Mock Update-ScoopApp {}
+    }
+
+    It 'completes without error' {
+        { Invoke-ScoopUpdate } | Should -Not -Throw
+    }
+}

--- a/lib/scoop/scoop.Tests.ps1
+++ b/lib/scoop/scoop.Tests.ps1
@@ -1,0 +1,214 @@
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0' }
+
+BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
+    . "$PSScriptRoot\scoop.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
+}
+
+Describe 'Get-ScoopUpdatableApp' {
+    BeforeEach {
+        Mock Invoke-CommandLine {}
+        Mock Write-Status {}
+    }
+
+    It 'returns empty array when scoop status returns null' {
+        Mock Invoke-CommandLine { return $null }
+
+        $result = @(Get-ScoopUpdatableApp)
+
+        $result.Count | Should -Be 0
+    }
+
+    It 'parses scoop status output with updatable apps' {
+        $statusOutput = @(
+            "Name      Installed Version  Latest Version  Missing Dependencies  Info"
+            "----      -----------------  --------------  --------------------  ----"
+            "7zip      24.08              24.09"
+            "git       2.46.0             2.47.0"
+        )
+        Mock Invoke-CommandLine { return $statusOutput }
+
+        $result = @(Get-ScoopUpdatableApp)
+
+        $result.Count | Should -Be 2
+        $result[0].Name | Should -Be '7zip'
+        $result[0].InstalledVersion | Should -Be '24.08'
+        $result[0].LatestVersion | Should -Be '24.09'
+        $result[1].Name | Should -Be 'git'
+        $result[1].InstalledVersion | Should -Be '2.46.0'
+        $result[1].LatestVersion | Should -Be '2.47.0'
+    }
+
+    It 'returns empty array when no apps need updating' {
+        $statusOutput = @(
+            "Name      Installed Version  Latest Version  Missing Dependencies  Info"
+            "----      -----------------  --------------  --------------------  ----"
+        )
+        Mock Invoke-CommandLine { return $statusOutput }
+
+        $result = @(Get-ScoopUpdatableApp)
+
+        $result.Count | Should -Be 0
+    }
+
+    It 'parses structured PSCustomObject output from modern scoop' {
+        $statusOutput = @(
+            [PSCustomObject]@{ Name = 'gimp'; 'Installed Version' = '3.0.8-2'; 'Latest Version' = '3.2.0'; 'Missing Dependencies' = ''; Info = '' }
+            [PSCustomObject]@{ Name = 'pwsh'; 'Installed Version' = '7.5.4'; 'Latest Version' = '7.5.5'; 'Missing Dependencies' = ''; Info = '' }
+        )
+        Mock Invoke-CommandLine { return $statusOutput }
+
+        $result = @(Get-ScoopUpdatableApp)
+
+        $result.Count | Should -Be 2
+        $result[0].Name | Should -Be 'gimp'
+        $result[0].InstalledVersion | Should -Be '3.0.8-2'
+        $result[0].LatestVersion | Should -Be '3.2.0'
+        $result[1].Name | Should -Be 'pwsh'
+    }
+
+    It 'handles single updatable app' {
+        $statusOutput = @(
+            "Name      Installed Version  Latest Version  Missing Dependencies  Info"
+            "----      -----------------  --------------  --------------------  ----"
+            "nodejs    20.11.0            22.0.0"
+        )
+        Mock Invoke-CommandLine { return $statusOutput }
+
+        $result = @(Get-ScoopUpdatableApp)
+
+        $result.Count | Should -Be 1
+        $result[0].Name | Should -Be 'nodejs'
+    }
+}
+
+Describe 'Show-ScoopUpdatableApp' {
+    BeforeEach {
+        Mock Write-Host {}
+    }
+
+    It 'displays header and app entries' {
+        $apps = @(
+            [PSCustomObject]@{ Name = '7zip'; InstalledVersion = '24.08'; LatestVersion = '24.09' }
+            [PSCustomObject]@{ Name = 'git'; InstalledVersion = '2.46.0'; LatestVersion = '2.47.0' }
+        )
+
+        Show-ScoopUpdatableApp -Apps $apps
+
+        Should -Invoke Write-Host -ParameterFilter { $Object -eq "Updatable Apps:" } -Times 1
+    }
+}
+
+Describe 'Select-ScoopApp' {
+    It 'returns all app names in CI environment' {
+        $apps = @(
+            [PSCustomObject]@{ Name = '7zip'; InstalledVersion = '24.08'; LatestVersion = '24.09' }
+            [PSCustomObject]@{ Name = 'git'; InstalledVersion = '2.46.0'; LatestVersion = '2.47.0' }
+        )
+
+        # Running in CI (GitHub Actions), so should return all
+        $result = @(Select-ScoopApp -Apps $apps)
+
+        $result.Count | Should -Be 2
+        $result | Should -Contain '7zip'
+        $result | Should -Contain 'git'
+    }
+}
+
+Describe 'Update-ScoopApp' {
+    BeforeEach {
+        Mock Invoke-CommandLine {}
+        Mock Write-Status {}
+        Mock Write-Success {}
+        Mock Write-ErrorMsg {}
+    }
+
+    It 'updates a single app successfully' {
+        $global:LASTEXITCODE = 0
+        Mock Invoke-CommandLine { $global:LASTEXITCODE = 0 }
+
+        Update-ScoopApp -AppNames @('7zip')
+
+        Should -Invoke Invoke-CommandLine -ParameterFilter { $CommandLine -eq 'scoop update 7zip' } -Times 1
+        Should -Invoke Write-Success -Times 1
+    }
+
+    It 'updates multiple apps' {
+        $global:LASTEXITCODE = 0
+        Mock Invoke-CommandLine { $global:LASTEXITCODE = 0 }
+
+        Update-ScoopApp -AppNames @('7zip', 'git')
+
+        Should -Invoke Invoke-CommandLine -Times 2
+    }
+
+    It 'reports error when update fails' {
+        Mock Invoke-CommandLine { $global:LASTEXITCODE = 1 }
+
+        Update-ScoopApp -AppNames @('broken-app')
+
+        Should -Invoke Write-ErrorMsg -Times 1
+    }
+}
+
+Describe 'Invoke-ScoopUpdate' {
+    BeforeEach {
+        Mock Write-Host {}
+        Mock Write-Status {}
+        Mock Write-Success {}
+        Mock Write-WarningMsg {}
+        Mock Write-ErrorMsg {}
+        Mock Invoke-CommandLine {}
+        Mock Get-Command { return $true }
+    }
+
+    It 'shows error when scoop is not installed' {
+        Mock Get-Command { return $null } -ParameterFilter { $Name -eq 'scoop' }
+
+        Invoke-ScoopUpdate
+
+        Should -Invoke Write-ErrorMsg -ParameterFilter { $Message -like '*Scoop is not installed*' } -Times 1
+    }
+
+    It 'shows up-to-date message when no updates available' {
+        Mock Get-ScoopUpdatableApp { return @() }
+
+        Invoke-ScoopUpdate
+
+        Should -Invoke Write-Success -ParameterFilter { $Message -like '*up to date*' } -Times 1
+    }
+
+    It 'runs full update flow when apps are updatable' {
+        $apps = @(
+            [PSCustomObject]@{ Name = '7zip'; InstalledVersion = '24.08'; LatestVersion = '24.09' }
+        )
+        Mock Get-ScoopUpdatableApp { return $apps }
+        Mock Show-ScoopUpdatableApp {}
+        Mock Select-ScoopApp { return @('7zip') }
+        Mock Update-ScoopApp {}
+
+        Invoke-ScoopUpdate
+
+        Should -Invoke Show-ScoopUpdatableApp -Times 1
+        Should -Invoke Select-ScoopApp -Times 1
+        Should -Invoke Update-ScoopApp -Times 1
+    }
+
+    It 'shows warning when no apps selected' {
+        $apps = @(
+            [PSCustomObject]@{ Name = '7zip'; InstalledVersion = '24.08'; LatestVersion = '24.09' }
+        )
+        Mock Get-ScoopUpdatableApp { return $apps }
+        Mock Show-ScoopUpdatableApp {}
+        Mock Select-ScoopApp { return @() }
+
+        Invoke-ScoopUpdate
+
+        Should -Invoke Write-WarningMsg -ParameterFilter { $Message -like '*No apps selected*' } -Times 1
+    }
+}

--- a/lib/scoop/scoop.Tests.ps1
+++ b/lib/scoop/scoop.Tests.ps1
@@ -25,13 +25,12 @@ Describe 'Get-ScoopUpdatableApp' {
     }
 
     It 'parses scoop status output with updatable apps' {
-        $statusOutput = @(
+        Mock Invoke-CommandLine { return @(
             "Name      Installed Version  Latest Version  Missing Dependencies  Info"
             "----      -----------------  --------------  --------------------  ----"
             "7zip      24.08              24.09"
             "git       2.46.0             2.47.0"
-        )
-        Mock Invoke-CommandLine { return $statusOutput }
+        ) }
 
         $result = @(Get-ScoopUpdatableApp)
 
@@ -45,11 +44,10 @@ Describe 'Get-ScoopUpdatableApp' {
     }
 
     It 'returns empty array when no apps need updating' {
-        $statusOutput = @(
+        Mock Invoke-CommandLine { return @(
             "Name      Installed Version  Latest Version  Missing Dependencies  Info"
             "----      -----------------  --------------  --------------------  ----"
-        )
-        Mock Invoke-CommandLine { return $statusOutput }
+        ) }
 
         $result = @(Get-ScoopUpdatableApp)
 
@@ -57,11 +55,10 @@ Describe 'Get-ScoopUpdatableApp' {
     }
 
     It 'parses structured PSCustomObject output from modern scoop' {
-        $statusOutput = @(
+        Mock Invoke-CommandLine { return @(
             [PSCustomObject]@{ Name = 'gimp'; 'Installed Version' = '3.0.8-2'; 'Latest Version' = '3.2.0'; 'Missing Dependencies' = ''; Info = '' }
             [PSCustomObject]@{ Name = 'pwsh'; 'Installed Version' = '7.5.4'; 'Latest Version' = '7.5.5'; 'Missing Dependencies' = ''; Info = '' }
-        )
-        Mock Invoke-CommandLine { return $statusOutput }
+        ) }
 
         $result = @(Get-ScoopUpdatableApp)
 
@@ -73,7 +70,7 @@ Describe 'Get-ScoopUpdatableApp' {
     }
 
     It 'skips blank lines and malformed rows in legacy output' {
-        $statusOutput = @(
+        Mock Invoke-CommandLine { return @(
             "Name      Installed Version  Latest Version  Missing Dependencies  Info"
             "----      -----------------  --------------  --------------------  ----"
             ""
@@ -81,8 +78,7 @@ Describe 'Get-ScoopUpdatableApp' {
             "   "
             "malformed-line"
             "git       2.46.0             2.47.0"
-        )
-        Mock Invoke-CommandLine { return $statusOutput }
+        ) }
 
         $result = @(Get-ScoopUpdatableApp)
 
@@ -92,12 +88,11 @@ Describe 'Get-ScoopUpdatableApp' {
     }
 
     It 'handles single updatable app' {
-        $statusOutput = @(
+        Mock Invoke-CommandLine { return @(
             "Name      Installed Version  Latest Version  Missing Dependencies  Info"
             "----      -----------------  --------------  --------------------  ----"
             "nodejs    20.11.0            22.0.0"
-        )
-        Mock Invoke-CommandLine { return $statusOutput }
+        ) }
 
         $result = @(Get-ScoopUpdatableApp)
 
@@ -224,7 +219,6 @@ Describe 'Update-ScoopApp' {
     }
 
     It 'updates a single app successfully' {
-        $global:LASTEXITCODE = 0
         Mock Invoke-CommandLine { $global:LASTEXITCODE = 0 }
 
         Update-ScoopApp -AppNames @('7zip')
@@ -234,7 +228,6 @@ Describe 'Update-ScoopApp' {
     }
 
     It 'updates multiple apps' {
-        $global:LASTEXITCODE = 0
         Mock Invoke-CommandLine { $global:LASTEXITCODE = 0 }
 
         Update-ScoopApp -AppNames @('7zip', 'git')

--- a/lib/scoop/scoop.Tests.ps1
+++ b/lib/scoop/scoop.Tests.ps1
@@ -72,6 +72,25 @@ Describe 'Get-ScoopUpdatableApp' {
         $result[1].Name | Should -Be 'pwsh'
     }
 
+    It 'skips blank lines and malformed rows in legacy output' {
+        $statusOutput = @(
+            "Name      Installed Version  Latest Version  Missing Dependencies  Info"
+            "----      -----------------  --------------  --------------------  ----"
+            ""
+            "7zip      24.08              24.09"
+            "   "
+            "malformed-line"
+            "git       2.46.0             2.47.0"
+        )
+        Mock Invoke-CommandLine { return $statusOutput }
+
+        $result = @(Get-ScoopUpdatableApp)
+
+        $result.Count | Should -Be 2
+        $result[0].Name | Should -Be '7zip'
+        $result[1].Name | Should -Be 'git'
+    }
+
     It 'handles single updatable app' {
         $statusOutput = @(
             "Name      Installed Version  Latest Version  Missing Dependencies  Info"
@@ -105,18 +124,94 @@ Describe 'Show-ScoopUpdatableApp' {
 }
 
 Describe 'Select-ScoopApp' {
-    It 'returns all app names in CI environment' {
-        $apps = @(
+    BeforeEach {
+        $script:testApps = @(
             [PSCustomObject]@{ Name = '7zip'; InstalledVersion = '24.08'; LatestVersion = '24.09' }
             [PSCustomObject]@{ Name = 'git'; InstalledVersion = '2.46.0'; LatestVersion = '2.47.0' }
+            [PSCustomObject]@{ Name = 'pwsh'; InstalledVersion = '7.5.4'; LatestVersion = '7.5.5' }
         )
+    }
 
-        # Running in CI (GitHub Actions), so should return all
-        $result = @(Select-ScoopApp -Apps $apps)
+    Context 'In CI environment' {
+        It 'returns all app names' {
+            Mock Test-RunningInCIorTestEnvironment { return $true }
 
-        $result.Count | Should -Be 2
-        $result | Should -Contain '7zip'
-        $result | Should -Contain 'git'
+            $result = @(Select-ScoopApp -Apps $script:testApps)
+
+            $result.Count | Should -Be 3
+            $result | Should -Contain '7zip'
+            $result | Should -Contain 'git'
+            $result | Should -Contain 'pwsh'
+        }
+    }
+
+    Context 'In interactive environment' {
+        BeforeEach {
+            Mock Test-RunningInCIorTestEnvironment { return $false }
+            Mock Write-WarningMsg {}
+        }
+
+        It 'returns all apps when user enters A' {
+            Mock Read-Host { return 'A' }
+
+            $result = @(Select-ScoopApp -Apps $script:testApps)
+
+            $result.Count | Should -Be 3
+        }
+
+        It 'returns all apps when user enters lowercase a' {
+            Mock Read-Host { return 'a' }
+
+            $result = @(Select-ScoopApp -Apps $script:testApps)
+
+            $result.Count | Should -Be 3
+        }
+
+        It 'returns selected apps by comma-separated numbers' {
+            Mock Read-Host { return '1,3' }
+
+            $result = @(Select-ScoopApp -Apps $script:testApps)
+
+            $result.Count | Should -Be 2
+            $result | Should -Contain '7zip'
+            $result | Should -Contain 'pwsh'
+        }
+
+        It 'warns on out-of-range number' {
+            Mock Read-Host { return '5' }
+
+            $result = @(Select-ScoopApp -Apps $script:testApps)
+
+            $result.Count | Should -Be 0
+            Should -Invoke Write-WarningMsg -ParameterFilter { $Message -like '*Invalid number*' }
+        }
+
+        It 'warns on non-numeric input' {
+            Mock Read-Host { return 'xyz' }
+
+            $result = @(Select-ScoopApp -Apps $script:testApps)
+
+            $result.Count | Should -Be 0
+            Should -Invoke Write-WarningMsg -ParameterFilter { $Message -like '*Invalid input*' }
+        }
+
+        It 'handles mixed valid and invalid input' {
+            Mock Read-Host { return '1,abc,99' }
+
+            $result = @(Select-ScoopApp -Apps $script:testApps)
+
+            $result.Count | Should -Be 1
+            $result | Should -Contain '7zip'
+            Should -Invoke Write-WarningMsg -Times 2
+        }
+
+        It 'returns empty array on empty input' {
+            Mock Read-Host { return '' }
+
+            $result = @(Select-ScoopApp -Apps $script:testApps)
+
+            $result.Count | Should -Be 0
+        }
     }
 }
 
@@ -147,6 +242,12 @@ Describe 'Update-ScoopApp' {
         Should -Invoke Invoke-CommandLine -Times 2
     }
 
+    It 'skips update when -WhatIf is used' {
+        Update-ScoopApp -AppNames @('7zip', 'git') -WhatIf
+
+        Should -Invoke Invoke-CommandLine -Times 0
+    }
+
     It 'reports error when update fails' {
         Mock Invoke-CommandLine { $global:LASTEXITCODE = 1 }
 
@@ -173,6 +274,14 @@ Describe 'Invoke-ScoopUpdate' {
         Invoke-ScoopUpdate
 
         Should -Invoke Write-ErrorMsg -ParameterFilter { $Message -like '*Scoop is not installed*' } -Times 1
+    }
+
+    It 'refreshes scoop before checking for updates' {
+        Mock Get-ScoopUpdatableApp { return @() }
+
+        Invoke-ScoopUpdate
+
+        Should -Invoke Invoke-CommandLine -ParameterFilter { $CommandLine -eq 'scoop update' } -Times 1
     }
 
     It 'shows up-to-date message when no updates available' {

--- a/lib/utils/utils.Integration.Tests.ps1
+++ b/lib/utils/utils.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 
 <#
 .SYNOPSIS
@@ -28,6 +28,8 @@ BeforeDiscovery {
 }
 
 BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     # Source the utilities module
     $script:utilsPath = Join-Path $PSScriptRoot "utils.ps1"
     . $script:utilsPath
@@ -72,6 +74,10 @@ BeforeAll {
     if (Get-Command npm -ErrorAction SilentlyContinue) {
         $null = Uninstall-NpmPackage -PackageName $script:testPackageName
     }
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "Install-NpmPackage" -Tag "Integration" -Skip:$script:skipTests {

--- a/lib/utils/utils.Tests.ps1
+++ b/lib/utils/utils.Tests.ps1
@@ -1,11 +1,16 @@
-<#
+﻿<#
 .DESCRIPTION
     Pester tests for utils.ps1 utility functions
 #>
 
 BeforeAll {
-    # Source the utils.ps1 file
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\utils.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "Invoke-CommandLine" {

--- a/lib/wsl/commands.Tests.ps1
+++ b/lib/wsl/commands.Tests.ps1
@@ -6,7 +6,13 @@
 param()
 
 BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\commands.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "Show-WslDistroList" {

--- a/lib/wsl/commands.Tests.ps1
+++ b/lib/wsl/commands.Tests.ps1
@@ -15,11 +15,76 @@ AfterAll {
     Stop-SutIsolation
 }
 
+Describe "Format-DistroListEntry" {
+    BeforeEach {
+        Mock Write-Host {}
+    }
+
+    It "Should display index number" {
+        $distro = [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false }
+
+        Format-DistroListEntry -Index 1 -Distro $distro
+
+        Should -Invoke Write-Host -ParameterFilter { $Object -like "*1.*" }
+    }
+
+    It "Should display distribution name" {
+        $distro = [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false }
+
+        Format-DistroListEntry -Index 1 -Distro $distro
+
+        Should -Invoke Write-Host -ParameterFilter { $Object -like "*Debian*" }
+    }
+
+    It "Should use green color for running state" {
+        $distro = [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false }
+
+        Format-DistroListEntry -Index 1 -Distro $distro
+
+        Should -Invoke Write-Host -ParameterFilter { $ForegroundColor -eq "Green" -and $Object -like "*Running*" }
+    }
+
+    It "Should use gray color for stopped state" {
+        $distro = [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
+
+        Format-DistroListEntry -Index 1 -Distro $distro
+
+        Should -Invoke Write-Host -ParameterFilter { $ForegroundColor -eq "Gray" -and $Object -like "*Stopped*" }
+    }
+
+    It "Should include Default indicator for default distribution" {
+        $distro = [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
+
+        Format-DistroListEntry -Index 1 -Distro $distro
+
+        Should -Invoke Write-Host -ParameterFilter { $Object -like "*Default*" }
+    }
+
+    It "Should not include Default indicator for non-default distribution" {
+        $distro = [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false }
+
+        Format-DistroListEntry -Index 1 -Distro $distro
+
+        Should -Invoke Write-Host -ParameterFilter { $Object -like "*Default*" } -Times 0
+    }
+
+    It "Should display WSL version number" {
+        $distro = [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 1; IsDefault = $false }
+
+        Format-DistroListEntry -Index 1 -Distro $distro
+
+        Should -Invoke Write-Host -ParameterFilter { $Object -like "*WSL1*" }
+    }
+}
+
 Describe "Show-WslDistroList" {
     Context "When WSL is installed" {
+        BeforeEach {
+            Mock Write-Host {}
+        }
+
         It "Should display message when no distributions are installed" {
             Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
 
             Show-WslDistroList
 
@@ -27,9 +92,7 @@ Describe "Show-WslDistroList" {
         }
 
         It "Should call Get-WslDistroList with -Detailed switch" {
-
             Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
 
             Show-WslDistroList
 
@@ -37,13 +100,9 @@ Describe "Show-WslDistroList" {
         }
 
         It "Should display distribution name and state" {
-
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
+                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
             } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
 
             Show-WslDistroList
 
@@ -52,13 +111,9 @@ Describe "Show-WslDistroList" {
         }
 
         It "Should display state with green color when running" {
-
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false }
-                )
+                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false })
             } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
 
             Show-WslDistroList
 
@@ -68,13 +123,9 @@ Describe "Show-WslDistroList" {
         }
 
         It "Should display state with gray color when stopped" {
-
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
-                )
+                @([PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false })
             } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
 
             Show-WslDistroList
 
@@ -84,13 +135,9 @@ Describe "Show-WslDistroList" {
         }
 
         It "Should display WSL version" {
-
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false }
-                )
+                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false })
             } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
 
             Show-WslDistroList
 
@@ -98,13 +145,9 @@ Describe "Show-WslDistroList" {
         }
 
         It "Should display default indicator for default distribution" {
-
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
+                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
             } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
 
             Show-WslDistroList
 
@@ -112,14 +155,12 @@ Describe "Show-WslDistroList" {
         }
 
         It "Should handle mixed running and stopped distributions" {
-
             Mock Get-WslDistroList {
                 @(
                     [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
                     [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
                 )
             } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
 
             Show-WslDistroList
 
@@ -134,13 +175,9 @@ Describe "Show-WslDistroList" {
         }
 
         It "Should display header" {
-
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false }
-                )
+                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false })
             } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
 
             Show-WslDistroList
 
@@ -149,10 +186,12 @@ Describe "Show-WslDistroList" {
     }
 
     Context "When pre-fetched Distros are provided" {
-        It "Should use provided distros and not call Get-WslDistroList" {
+        BeforeEach {
             Mock Get-WslDistroList {}
             Mock Write-Host {}
+        }
 
+        It "Should use provided distros and not call Get-WslDistroList" {
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
             )
@@ -164,9 +203,6 @@ Describe "Show-WslDistroList" {
         }
 
         It "Should display provided distros without re-fetching" {
-            Mock Get-WslDistroList {}
-            Mock Write-Host {}
-
             $distros = @(
                 [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false },
                 [PSCustomObject]@{ Name = "Fedora"; State = "Running"; Version = 2; IsDefault = $false }
@@ -180,9 +216,6 @@ Describe "Show-WslDistroList" {
         }
 
         It "Should display no-distributions message when provided empty list" {
-            Mock Get-WslDistroList {}
-            Mock Write-Host {}
-
             Show-WslDistroList -Distros @()
 
             Should -Invoke Get-WslDistroList -Times 0
@@ -193,6 +226,10 @@ Describe "Show-WslDistroList" {
 
 Describe "Select-WslDistro" {
     Context "When selecting by number" {
+        BeforeEach {
+            Mock Write-Host {}
+        }
+
         It "Should return the distro name for a valid number" {
             Mock Get-WslDistroList {
                 @(
@@ -200,7 +237,6 @@ Describe "Select-WslDistro" {
                     [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
                 )
             } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             Mock Read-Host { "2" }
 
             $result = Select-WslDistro
@@ -209,9 +245,7 @@ Describe "Select-WslDistro" {
         }
 
         It "Should return null for an out-of-range number" {
-            Mock Write-Host {}
             Mock Read-Host { "99" }
-
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
             )
@@ -223,10 +257,12 @@ Describe "Select-WslDistro" {
     }
 
     Context "When selecting by name" {
-        It "Should return the name as-is" {
+        BeforeEach {
             Mock Write-Host {}
-            Mock Read-Host { "Ubuntu" }
+        }
 
+        It "Should return the name as-is" {
+            Mock Read-Host { "Ubuntu" }
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
                 [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
@@ -238,9 +274,7 @@ Describe "Select-WslDistro" {
         }
 
         It "Should return null for a name not in the list" {
-            Mock Write-Host {}
             Mock Read-Host { "NonExistent" }
-
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
             )
@@ -253,9 +287,11 @@ Describe "Select-WslDistro" {
     }
 
     Context "When selection is pre-provided" {
-        It "Should resolve a pre-provided number without prompting" {
+        BeforeEach {
             Mock Read-Host {}
+        }
 
+        It "Should resolve a pre-provided number without prompting" {
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
                 [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
@@ -268,8 +304,6 @@ Describe "Select-WslDistro" {
         }
 
         It "Should return a pre-provided name without prompting" {
-            Mock Read-Host {}
-
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
             )
@@ -286,7 +320,6 @@ Describe "Select-WslDistro" {
             Mock Write-Host {}
             Mock Read-Host { "" }
             Mock Write-WarningMsg {}
-
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
             )
@@ -299,9 +332,12 @@ Describe "Select-WslDistro" {
     }
 
     Context "When no distributions exist" {
+        BeforeEach {
+            Mock Write-WarningMsg {}
+        }
+
         It "Should return null and warn" {
             Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
-            Mock Write-WarningMsg {}
 
             $result = Select-WslDistro
 
@@ -310,8 +346,6 @@ Describe "Select-WslDistro" {
         }
 
         It "Should return null when pre-fetched list is empty" {
-            Mock Write-WarningMsg {}
-
             $result = Select-WslDistro -Distros @()
 
             $result | Should -BeNullOrEmpty
@@ -320,14 +354,15 @@ Describe "Select-WslDistro" {
     }
 
     Context "Table display logic" {
-        It "Should show the table when Distros are not pre-fetched" {
-            Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
-            } -ParameterFilter { $Detailed }
+        BeforeEach {
             Mock Write-Host {}
             Mock Read-Host { "1" }
+        }
+
+        It "Should show the table when Distros are not pre-fetched" {
+            Mock Get-WslDistroList {
+                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
+            } -ParameterFilter { $Detailed }
 
             Select-WslDistro
 
@@ -336,9 +371,6 @@ Describe "Select-WslDistro" {
         }
 
         It "Should not show the table when Distros are pre-fetched" {
-            Mock Write-Host {}
-            Mock Read-Host { "1" }
-
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
             )
@@ -350,8 +382,6 @@ Describe "Select-WslDistro" {
 
         It "Should not call Get-WslDistroList when Distros are pre-fetched" {
             Mock Get-WslDistroList {}
-            Mock Read-Host { "1" }
-
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
             )
@@ -389,7 +419,7 @@ Describe "Invoke-WslCommand" {
             Should -Invoke Invoke-CloneDistro -ParameterFilter { $SourceName -eq "Debian" -and $TargetName -eq "Debian-Clone" }
         }
 
-        It "Should dispatch 'remove' with Selection" {
+        It "Should dispatch 'remove' with Name" {
             Mock Invoke-RemoveDistro {}
 
             Invoke-WslCommand -Command "remove" -Name "Debian"
@@ -397,7 +427,7 @@ Describe "Invoke-WslCommand" {
             Should -Invoke Invoke-RemoveDistro -ParameterFilter { $Name -eq "Debian" }
         }
 
-        It "Should dispatch 'update' with Selection" {
+        It "Should dispatch 'update' with Name" {
             Mock Invoke-UpdateDistro {}
 
             Invoke-WslCommand -Command "update" -Name "Debian"
@@ -483,6 +513,172 @@ Describe "Invoke-WslCommand" {
     }
 }
 
+Describe "Invoke-CreateDistro" {
+    Context "When Name is provided" {
+        BeforeEach {
+            Mock Write-Host {}
+            Mock New-WslDistro {}
+        }
+
+        It "Should install the named distribution" {
+            Mock Get-WslAvailableDistro { @("Debian", "Ubuntu", "kali-linux") }
+
+            Invoke-CreateDistro -Name "Debian"
+
+            Should -Invoke New-WslDistro -ParameterFilter { $Name -eq "Debian" -and $Confirm -eq $false }
+        }
+
+        It "Should reject an unavailable distribution name" {
+            Mock Get-WslAvailableDistro { @("Debian", "Ubuntu") }
+
+            Invoke-CreateDistro -Name "NonExistent"
+
+            Should -Invoke Write-Host -ParameterFilter { $Object -like "*not available*" }
+            Should -Invoke New-WslDistro -Times 0
+        }
+    }
+
+    Context "When Name is not provided" {
+        BeforeEach {
+            Mock Get-WslAvailableDistro { @("Debian", "Ubuntu") }
+            Mock Write-Host {}
+            Mock New-WslDistro {}
+        }
+
+        It "Should prompt and install the selected distribution by number" {
+            Mock Read-Host { "1" }
+
+            Invoke-CreateDistro
+
+            Should -Invoke New-WslDistro -ParameterFilter { $Name -eq "Debian" -and $Confirm -eq $false }
+        }
+
+        It "Should prompt and install the selected distribution by name" {
+            Mock Read-Host { "Ubuntu" }
+
+            Invoke-CreateDistro
+
+            Should -Invoke New-WslDistro -ParameterFilter { $Name -eq "Ubuntu" -and $Confirm -eq $false }
+        }
+
+        It "Should cancel on empty input" {
+            Mock Read-Host { "" }
+            Mock Write-WarningMsg {}
+
+            Invoke-CreateDistro
+
+            Should -Invoke New-WslDistro -Times 0
+        }
+
+        It "Should reject an invalid number" {
+            Mock Read-Host { "99" }
+
+            Invoke-CreateDistro
+
+            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Invalid selection*" }
+            Should -Invoke New-WslDistro -Times 0
+        }
+    }
+}
+
+Describe "Invoke-RemoveDistro" {
+    Context "When Name is provided" {
+        It "Should dispatch to Remove-WslDistro with selected name" {
+            Mock Select-WslDistro { "Debian" }
+            Mock Remove-WslDistro {}
+
+            Invoke-RemoveDistro -Name "Debian"
+
+            Should -Invoke Select-WslDistro -ParameterFilter { $Selection -eq "Debian" }
+            Should -Invoke Remove-WslDistro -ParameterFilter { $Name -eq "Debian" -and $Confirm -eq $false }
+        }
+    }
+
+    Context "When Name is not provided" {
+        It "Should prompt via Select-WslDistro and remove selected distro" {
+            Mock Select-WslDistro { "Ubuntu" }
+            Mock Remove-WslDistro {}
+
+            Invoke-RemoveDistro
+
+            Should -Invoke Select-WslDistro -Times 1
+            Should -Invoke Remove-WslDistro -ParameterFilter { $Name -eq "Ubuntu" }
+        }
+
+        It "Should return early when selection is cancelled" {
+            Mock Select-WslDistro { $null }
+            Mock Remove-WslDistro {}
+
+            Invoke-RemoveDistro
+
+            Should -Invoke Remove-WslDistro -Times 0
+        }
+    }
+
+    Context "When Distros are pre-fetched" {
+        It "Should pass Distros to Select-WslDistro" {
+            $distros = @(
+                [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
+            )
+            Mock Select-WslDistro { "Debian" }
+            Mock Remove-WslDistro {}
+
+            Invoke-RemoveDistro -Distros $distros
+
+            Should -Invoke Select-WslDistro -ParameterFilter { $null -ne $Distros }
+        }
+    }
+}
+
+Describe "Invoke-UpdateDistro" {
+    Context "When Name is provided" {
+        It "Should dispatch to Update-WslDistro with selected name" {
+            Mock Select-WslDistro { "Debian" }
+            Mock Update-WslDistro {}
+
+            Invoke-UpdateDistro -Name "Debian"
+
+            Should -Invoke Select-WslDistro -ParameterFilter { $Selection -eq "Debian" }
+            Should -Invoke Update-WslDistro -ParameterFilter { $Name -eq "Debian" -and $Confirm -eq $false }
+        }
+    }
+
+    Context "When Name is not provided" {
+        It "Should prompt via Select-WslDistro and update selected distro" {
+            Mock Select-WslDistro { "Ubuntu" }
+            Mock Update-WslDistro {}
+
+            Invoke-UpdateDistro
+
+            Should -Invoke Select-WslDistro -Times 1
+            Should -Invoke Update-WslDistro -ParameterFilter { $Name -eq "Ubuntu" }
+        }
+
+        It "Should return early when selection is cancelled" {
+            Mock Select-WslDistro { $null }
+            Mock Update-WslDistro {}
+
+            Invoke-UpdateDistro
+
+            Should -Invoke Update-WslDistro -Times 0
+        }
+    }
+
+    Context "When Distros are pre-fetched" {
+        It "Should pass Distros to Select-WslDistro" {
+            $distros = @(
+                [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
+            )
+            Mock Select-WslDistro { "Debian" }
+            Mock Update-WslDistro {}
+
+            Invoke-UpdateDistro -Distros $distros
+
+            Should -Invoke Select-WslDistro -ParameterFilter { $null -ne $Distros }
+        }
+    }
+}
+
 Describe "Invoke-TerminateDistro" {
     Context "When no distributions are running" {
         It "Should display informational message and return" {
@@ -503,28 +699,21 @@ Describe "Invoke-TerminateDistro" {
     }
 
     Context "When running in CI environment" {
-        It "Should throw error if Name is not provided" {
+        BeforeEach {
             Mock Test-RunningInCIorTestEnvironment { $true }
-
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
+                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
             } -ParameterFilter { $Detailed }
             Mock Test-WslDistroRunning { $true }
+        }
 
-            { Invoke-TerminateDistro } | Should -Throw "*Cannot run interactive*"
+        It "Should throw error if Name is not provided" {
+            $act = { Invoke-TerminateDistro }
+
+            $act | Should -Throw "*Cannot run interactive*"
         }
 
         It "Should proceed if Name is provided" {
-            Mock Test-RunningInCIorTestEnvironment { $true }
-
-            Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
-            } -ParameterFilter { $Detailed }
-            Mock Test-WslDistroRunning { $true }
             Mock Stop-WslDistro { }
 
             Invoke-TerminateDistro -Name "Debian"
@@ -535,7 +724,6 @@ Describe "Invoke-TerminateDistro" {
 
     Context "When distributions are running" {
         BeforeEach {
-
             Mock Test-RunningInCIorTestEnvironment { $false }
             Mock Get-WslDistroList {
                 @(
@@ -599,7 +787,6 @@ Describe "Invoke-TerminateDistro" {
 
         It "Should handle invalid number" {
             Mock Read-Host { "99" }
-            Mock Write-Host {}
 
             Invoke-TerminateDistro
 
@@ -609,7 +796,6 @@ Describe "Invoke-TerminateDistro" {
 
         It "Should handle non-running distribution name" {
             Mock Read-Host { "Alpine" }
-            Mock Write-Host {}
 
             Invoke-TerminateDistro
 
@@ -619,7 +805,6 @@ Describe "Invoke-TerminateDistro" {
 
         It "Should error when selecting stopped distro by number" {
             Mock Read-Host { "3" }
-            Mock Write-Host {}
 
             Invoke-TerminateDistro
 
@@ -628,17 +813,16 @@ Describe "Invoke-TerminateDistro" {
         }
     }
 
-    Context "When called with pre-fetched Distros (interactive menu mode)" {
+    Context "When called with pre-fetched Distros" {
         BeforeEach {
             Mock Test-RunningInCIorTestEnvironment { $false }
             Mock Write-Host {}
             Mock Stop-WslDistro {}
+            Mock Get-WslDistroList {}
         }
 
         It "Should not call Get-WslDistroList when Distros are provided" {
-            Mock Get-WslDistroList {}
             Mock Read-Host { "1" }
-
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
                 [PSCustomObject]@{ Name = "Ubuntu"; State = "Running"; Version = 2; IsDefault = $false }
@@ -651,9 +835,7 @@ Describe "Invoke-TerminateDistro" {
         }
 
         It "Should use full list numbering consistent with menu" {
-            Mock Get-WslDistroList {}
             Mock Read-Host { "3" }
-
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Stopped"; Version = 2; IsDefault = $true },
                 [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false },
@@ -666,9 +848,7 @@ Describe "Invoke-TerminateDistro" {
         }
 
         It "Should error when stopped distro selected by number from full list" {
-            Mock Get-WslDistroList {}
             Mock Read-Host { "1" }
-
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Stopped"; Version = 2; IsDefault = $true },
                 [PSCustomObject]@{ Name = "Ubuntu"; State = "Running"; Version = 2; IsDefault = $false }
@@ -681,9 +861,7 @@ Describe "Invoke-TerminateDistro" {
         }
 
         It "Should not reprint the distro table when Distros are provided" {
-            Mock Get-WslDistroList {}
             Mock Read-Host { "Ubuntu" }
-
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
                 [PSCustomObject]@{ Name = "Ubuntu"; State = "Running"; Version = 2; IsDefault = $false }
@@ -697,148 +875,14 @@ Describe "Invoke-TerminateDistro" {
     }
 }
 
-Describe "Invoke-RepairInterop" {
-    Context "When DistroName is provided" {
-        It "Should check interop configuration and repair if needed" {
-            Mock Write-Host {}
-            Mock Test-WslInteropConfigured { $false }
-            Mock Set-WslConf {}
-
-            Invoke-RepairInterop -DistroName "Debian"
-
-            Should -Invoke Test-WslInteropConfigured -ParameterFilter { $DistroName -eq "Debian" }
-            Should -Invoke Set-WslConf -ParameterFilter {
-                $DistroName -eq "Debian" -and
-                $Sections.interop.enabled -eq "true" -and
-                $Sections.interop.appendWindowsPath -eq "true"
-            }
-        }
-
-        It "Should skip repair when interop is already configured" {
-            Mock Write-Host {}
-            Mock Test-WslInteropConfigured { $true }
-            Mock Set-WslConf {}
-
-            Invoke-RepairInterop -DistroName "Debian"
-
-            Should -Invoke Test-WslInteropConfigured -ParameterFilter { $DistroName -eq "Debian" }
-            Should -Invoke Set-WslConf -Times 0
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*already configured*" }
-        }
-    }
-
-    Context "When DistroName is not provided" {
-        It "Should prompt for distribution selection" {
-            Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
-                    [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
-                )
-            } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
-            Mock Read-Host { "Debian" }
-            Mock Test-WslInteropConfigured { $false }
-            Mock Set-WslConf {}
-
-            Invoke-RepairInterop
-
-            Should -Invoke Read-Host -ParameterFilter { $Prompt -like "*number or name*" }
-            Should -Invoke Set-WslConf -ParameterFilter { $DistroName -eq "Debian" }
-        }
-
-        It "Should handle selection by number" {
-            Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
-                    [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
-                )
-            } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
-            Mock Read-Host { "2" }
-            Mock Test-WslInteropConfigured { $false }
-            Mock Set-WslConf {}
-
-            Invoke-RepairInterop
-
-            Should -Invoke Set-WslConf -ParameterFilter { $DistroName -eq "Ubuntu" }
-        }
-
-        It "Should cancel when no selection provided" {
-            Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
-            } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
-            Mock Read-Host { "" }
-            Mock Test-WslInteropConfigured { $false }
-            Mock Set-WslConf {}
-
-            Invoke-RepairInterop
-
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*cancel*" }
-            Should -Invoke Set-WslConf -Times 0
-        }
-
-        It "Should reject invalid number selection" {
-            Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
-                    [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
-                )
-            } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
-            Mock Read-Host { "99" }
-            Mock Test-WslInteropConfigured { $false }
-            Mock Set-WslConf {}
-
-            Invoke-RepairInterop
-
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Invalid selection*" }
-            Should -Invoke Set-WslConf -Times 0
-        }
-
-        It "Should warn when no distributions exist" {
-            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
-            Mock Write-WarningMsg {}
-            Mock Test-WslInteropConfigured {}
-            Mock Set-WslConf {}
-
-            Invoke-RepairInterop
-
-            Should -Invoke Write-WarningMsg -ParameterFilter { $Message -like "*No WSL distributions*" }
-            Should -Invoke Set-WslConf -Times 0
-        }
-    }
-
-    Context "When called with pre-fetched Distros" {
-        It "Should not call Get-WslDistroList when Distros are provided" {
-            Mock Get-WslDistroList {}
-            Mock Write-Host {}
-            Mock Read-Host { "1" }
-            Mock Test-WslInteropConfigured { $false }
-            Mock Set-WslConf {}
-
-            $distros = @(
-                [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
-                [PSCustomObject]@{ Name = "Ubuntu"; State = "Running"; Version = 2; IsDefault = $false }
-            )
-
-            Invoke-RepairInterop -Distros $distros
-
-            Should -Invoke Get-WslDistroList -Times 0
-            Should -Invoke Set-WslConf -ParameterFilter { $DistroName -eq "Debian" }
-        }
-    }
-}
-
 Describe "Invoke-SetupUser" {
     Context "When DistroName is provided with credentials" {
-        It "Should call New-WslUser directly without prompting" {
+        BeforeEach {
             Mock Write-Host {}
             Mock New-WslUser {}
+        }
 
+        It "Should call New-WslUser directly without prompting" {
             Invoke-SetupUser -DistroName "Debian" -Username "testuser" -Password "pass"
 
             Should -Invoke New-WslUser -ParameterFilter {
@@ -847,9 +891,6 @@ Describe "Invoke-SetupUser" {
         }
 
         It "Should display success message after user creation" {
-            Mock Write-Host {}
-            Mock New-WslUser {}
-
             Invoke-SetupUser -DistroName "Ubuntu" -Username "developer" -Password "pass"
 
             Should -Invoke Write-Host -ParameterFilter { $Object -like "*Successfully created user*" }
@@ -857,7 +898,7 @@ Describe "Invoke-SetupUser" {
     }
 
     Context "When DistroName is not provided" {
-        It "Should prompt for distribution selection by name" {
+        BeforeEach {
             Mock Get-WslDistroList {
                 @(
                     [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
@@ -865,9 +906,12 @@ Describe "Invoke-SetupUser" {
                 )
             } -ParameterFilter { $Detailed }
             Mock Write-Host {}
+            Mock New-WslUser {}
+        }
+
+        It "Should prompt for distribution selection by name" {
             Mock Read-Host { "Debian" }
             Mock Test-RunningInCIorTestEnvironment { $true }
-            Mock New-WslUser {}
 
             Invoke-SetupUser -Username "testuser" -Password "pass"
 
@@ -875,16 +919,8 @@ Describe "Invoke-SetupUser" {
         }
 
         It "Should prompt for distribution selection by number" {
-            Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
-                    [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
-                )
-            } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             Mock Read-Host { "2" }
             Mock Test-RunningInCIorTestEnvironment { $true }
-            Mock New-WslUser {}
 
             Invoke-SetupUser -Username "testuser" -Password "pass"
 
@@ -892,14 +928,7 @@ Describe "Invoke-SetupUser" {
         }
 
         It "Should cancel when no selection provided" {
-            Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
-            } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             Mock Read-Host { "" }
-            Mock New-WslUser {}
 
             Invoke-SetupUser -Username "testuser" -Password "pass"
 
@@ -908,15 +937,7 @@ Describe "Invoke-SetupUser" {
         }
 
         It "Should reject invalid number selection" {
-            Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
-                    [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
-                )
-            } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             Mock Read-Host { "99" }
-            Mock New-WslUser {}
 
             Invoke-SetupUser -Username "testuser" -Password "pass"
 
@@ -926,9 +947,7 @@ Describe "Invoke-SetupUser" {
 
         It "Should warn when no distributions exist" {
             Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             Mock Write-WarningMsg {}
-            Mock New-WslUser {}
 
             Invoke-SetupUser -Username "testuser" -Password "pass"
 
@@ -944,7 +963,6 @@ Describe "Invoke-SetupUser" {
             Mock Read-Host { "1" }
             Mock Test-RunningInCIorTestEnvironment { $true }
             Mock New-WslUser {}
-
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
                 [PSCustomObject]@{ Name = "Ubuntu"; State = "Running"; Version = 2; IsDefault = $false }
@@ -973,29 +991,29 @@ Describe "Invoke-SetupUser" {
 
 Describe "Invoke-SetupDocker" {
     Context "When DistroName is provided" {
-        It "Should call Install-WslDockerEngine directly" {
+        BeforeEach {
             Mock Write-Host {}
             Mock Install-WslDockerEngine { $true }
+        }
 
+        It "Should call Install-WslDockerEngine directly" {
             Invoke-SetupDocker -DistroName "Debian"
 
             Should -Invoke Install-WslDockerEngine -ParameterFilter { $DistroName -eq "Debian" -and $Confirm -eq $false }
         }
 
         It "Should display success message" {
-            Mock Write-Host {}
-            Mock Install-WslDockerEngine { $true }
-
             Invoke-SetupDocker -DistroName "Ubuntu"
 
             Should -Invoke Write-Host -ParameterFilter { $Object -like "*Successfully installed Docker*" }
         }
 
         It "Should propagate errors" {
-            Mock Write-Host {}
             Mock Install-WslDockerEngine { throw "Docker install failed" }
 
-            { Invoke-SetupDocker -DistroName "Debian" } | Should -Throw "*Docker install failed*"
+            $act = { Invoke-SetupDocker -DistroName "Debian" }
+
+            $act | Should -Throw "*Docker install failed*"
         }
     }
 
@@ -1016,29 +1034,29 @@ Describe "Invoke-SetupDocker" {
 
 Describe "Invoke-SetupPodman" {
     Context "When DistroName is provided" {
-        It "Should call Install-WslPodman directly" {
+        BeforeEach {
             Mock Write-Host {}
             Mock Install-WslPodman { $true }
+        }
 
+        It "Should call Install-WslPodman directly" {
             Invoke-SetupPodman -DistroName "Debian"
 
             Should -Invoke Install-WslPodman -ParameterFilter { $DistroName -eq "Debian" -and $Confirm -eq $false }
         }
 
         It "Should display success message" {
-            Mock Write-Host {}
-            Mock Install-WslPodman { $true }
-
             Invoke-SetupPodman -DistroName "Ubuntu"
 
             Should -Invoke Write-Host -ParameterFilter { $Object -like "*Successfully installed Podman*" }
         }
 
         It "Should propagate errors" {
-            Mock Write-Host {}
             Mock Install-WslPodman { throw "Podman install failed" }
 
-            { Invoke-SetupPodman -DistroName "Debian" } | Should -Throw "*Podman install failed*"
+            $act = { Invoke-SetupPodman -DistroName "Debian" }
+
+            $act | Should -Throw "*Podman install failed*"
         }
     }
 
@@ -1059,29 +1077,29 @@ Describe "Invoke-SetupPodman" {
 
 Describe "Invoke-SetupProxy" {
     Context "When DistroName is provided" {
-        It "Should call Install-WslProxy directly" {
+        BeforeEach {
             Mock Write-Host {}
             Mock Install-WslProxy { $true }
+        }
 
+        It "Should call Install-WslProxy directly" {
             Invoke-SetupProxy -DistroName "Debian"
 
             Should -Invoke Install-WslProxy -ParameterFilter { $DistroName -eq "Debian" -and $Confirm -eq $false }
         }
 
         It "Should display success message" {
-            Mock Write-Host {}
-            Mock Install-WslProxy { $true }
-
             Invoke-SetupProxy -DistroName "Ubuntu"
 
             Should -Invoke Write-Host -ParameterFilter { $Object -like "*Successfully configured proxy*" }
         }
 
         It "Should propagate errors" {
-            Mock Write-Host {}
             Mock Install-WslProxy { throw "Proxy config failed" }
 
-            { Invoke-SetupProxy -DistroName "Debian" } | Should -Throw "*Proxy config failed*"
+            $act = { Invoke-SetupProxy -DistroName "Debian" }
+
+            $act | Should -Throw "*Proxy config failed*"
         }
     }
 
@@ -1100,75 +1118,113 @@ Describe "Invoke-SetupProxy" {
     }
 }
 
-Describe "Invoke-CreateDistro" {
-    Context "When Name is provided" {
-        It "Should install the named distribution" {
-            Mock Get-WslAvailableDistro { @("Debian", "Ubuntu", "kali-linux") }
+Describe "Invoke-RepairInterop" {
+    Context "When DistroName is provided" {
+        BeforeEach {
             Mock Write-Host {}
-            Mock New-WslDistro {}
-
-            Invoke-CreateDistro -Name "Debian"
-
-            Should -Invoke New-WslDistro -ParameterFilter { $Name -eq "Debian" -and $Confirm -eq $false }
         }
 
-        It "Should reject an unavailable distribution name" {
-            Mock Get-WslAvailableDistro { @("Debian", "Ubuntu") }
-            Mock Write-Host {}
-            Mock New-WslDistro {}
+        It "Should check interop configuration and repair if needed" {
+            Mock Test-WslInteropConfigured { $false }
+            Mock Set-WslConf {}
 
-            Invoke-CreateDistro -Name "NonExistent"
+            Invoke-RepairInterop -DistroName "Debian"
 
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*not available*" }
-            Should -Invoke New-WslDistro -Times 0
+            Should -Invoke Test-WslInteropConfigured -ParameterFilter { $DistroName -eq "Debian" }
+            Should -Invoke Set-WslConf -ParameterFilter {
+                $DistroName -eq "Debian" -and
+                $Sections.interop.enabled -eq "true" -and
+                $Sections.interop.appendWindowsPath -eq "true"
+            }
+        }
+
+        It "Should skip repair when interop is already configured" {
+            Mock Test-WslInteropConfigured { $true }
+            Mock Set-WslConf {}
+
+            Invoke-RepairInterop -DistroName "Debian"
+
+            Should -Invoke Test-WslInteropConfigured -ParameterFilter { $DistroName -eq "Debian" }
+            Should -Invoke Set-WslConf -Times 0
+            Should -Invoke Write-Host -ParameterFilter { $Object -like "*already configured*" }
         }
     }
 
-    Context "When Name is not provided" {
-        It "Should prompt and install the selected distribution by number" {
-            Mock Get-WslAvailableDistro { @("Debian", "Ubuntu") }
+    Context "When DistroName is not provided" {
+        BeforeEach {
+            Mock Get-WslDistroList {
+                @(
+                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
+                    [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
+                )
+            } -ParameterFilter { $Detailed }
             Mock Write-Host {}
-            Mock Read-Host { "1" }
-            Mock New-WslDistro {}
-
-            Invoke-CreateDistro
-
-            Should -Invoke New-WslDistro -ParameterFilter { $Name -eq "Debian" -and $Confirm -eq $false }
+            Mock Test-WslInteropConfigured { $false }
+            Mock Set-WslConf {}
         }
 
-        It "Should prompt and install the selected distribution by name" {
-            Mock Get-WslAvailableDistro { @("Debian", "Ubuntu") }
-            Mock Write-Host {}
-            Mock Read-Host { "Ubuntu" }
-            Mock New-WslDistro {}
+        It "Should prompt for distribution selection" {
+            Mock Read-Host { "Debian" }
 
-            Invoke-CreateDistro
+            Invoke-RepairInterop
 
-            Should -Invoke New-WslDistro -ParameterFilter { $Name -eq "Ubuntu" -and $Confirm -eq $false }
+            Should -Invoke Read-Host -ParameterFilter { $Prompt -like "*number or name*" }
+            Should -Invoke Set-WslConf -ParameterFilter { $DistroName -eq "Debian" }
         }
 
-        It "Should cancel on empty input" {
-            Mock Get-WslAvailableDistro { @("Debian", "Ubuntu") }
-            Mock Write-Host {}
+        It "Should handle selection by number" {
+            Mock Read-Host { "2" }
+
+            Invoke-RepairInterop
+
+            Should -Invoke Set-WslConf -ParameterFilter { $DistroName -eq "Ubuntu" }
+        }
+
+        It "Should cancel when no selection provided" {
             Mock Read-Host { "" }
-            Mock Write-WarningMsg {}
-            Mock New-WslDistro {}
 
-            Invoke-CreateDistro
+            Invoke-RepairInterop
 
-            Should -Invoke New-WslDistro -Times 0
+            Should -Invoke Write-Host -ParameterFilter { $Object -like "*cancel*" }
+            Should -Invoke Set-WslConf -Times 0
         }
 
-        It "Should reject an invalid number" {
-            Mock Get-WslAvailableDistro { @("Debian", "Ubuntu") }
-            Mock Write-Host {}
+        It "Should reject invalid number selection" {
             Mock Read-Host { "99" }
-            Mock New-WslDistro {}
 
-            Invoke-CreateDistro
+            Invoke-RepairInterop
 
             Should -Invoke Write-Host -ParameterFilter { $Object -like "*Invalid selection*" }
-            Should -Invoke New-WslDistro -Times 0
+            Should -Invoke Set-WslConf -Times 0
+        }
+
+        It "Should warn when no distributions exist" {
+            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
+            Mock Write-WarningMsg {}
+
+            Invoke-RepairInterop
+
+            Should -Invoke Write-WarningMsg -ParameterFilter { $Message -like "*No WSL distributions*" }
+            Should -Invoke Set-WslConf -Times 0
+        }
+    }
+
+    Context "When called with pre-fetched Distros" {
+        It "Should not call Get-WslDistroList when Distros are provided" {
+            Mock Get-WslDistroList {}
+            Mock Write-Host {}
+            Mock Read-Host { "1" }
+            Mock Test-WslInteropConfigured { $false }
+            Mock Set-WslConf {}
+            $distros = @(
+                [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
+                [PSCustomObject]@{ Name = "Ubuntu"; State = "Running"; Version = 2; IsDefault = $false }
+            )
+
+            Invoke-RepairInterop -Distros $distros
+
+            Should -Invoke Get-WslDistroList -Times 0
+            Should -Invoke Set-WslConf -ParameterFilter { $DistroName -eq "Debian" }
         }
     }
 }
@@ -1185,7 +1241,7 @@ Describe "Invoke-CloneDistro" {
     }
 
     Context "When SourceName is not provided" {
-        It "Should prompt for source distribution" {
+        BeforeEach {
             Mock Get-WslDistroList {
                 @(
                     [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
@@ -1193,8 +1249,11 @@ Describe "Invoke-CloneDistro" {
                 )
             } -ParameterFilter { $Detailed }
             Mock Write-Host {}
-            Mock Read-Host { "1" }
             Mock Copy-WslDistro {}
+        }
+
+        It "Should prompt for source distribution" {
+            Mock Read-Host { "1" }
 
             Invoke-CloneDistro -TargetName "MyClone"
 
@@ -1202,14 +1261,7 @@ Describe "Invoke-CloneDistro" {
         }
 
         It "Should cancel when no source selection provided" {
-            Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
-            } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             Mock Read-Host { "" }
-            Mock Copy-WslDistro {}
 
             Invoke-CloneDistro -TargetName "MyClone"
 
@@ -1218,11 +1270,13 @@ Describe "Invoke-CloneDistro" {
     }
 
     Context "When TargetName is not provided" {
-        It "Should prompt for target name" {
+        BeforeEach {
             Mock Write-Host {}
-            Mock Read-Host { "MyClone" }
             Mock Copy-WslDistro {}
+        }
 
+        It "Should prompt for target name" {
+            Mock Read-Host { "MyClone" }
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
             )
@@ -1233,10 +1287,8 @@ Describe "Invoke-CloneDistro" {
         }
 
         It "Should cancel when no target name provided" {
-            Mock Write-Host {}
             Mock Read-Host { "" }
             Mock Write-WarningMsg {}
-            Mock Copy-WslDistro {}
 
             Invoke-CloneDistro -SourceName "Debian"
 
@@ -1277,9 +1329,7 @@ Describe "Invoke-ShutdownWsl" {
     Context "When no distributions are running" {
         BeforeEach {
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Stopped"; Version = 2; IsDefault = $true }
-                )
+                @([PSCustomObject]@{ Name = "Debian"; State = "Stopped"; Version = 2; IsDefault = $true })
             } -ParameterFilter { $Detailed }
             Mock Stop-WslSubsystem { }
             Mock Write-Host { }
@@ -1349,4 +1399,3 @@ Describe "Invoke-ConfigureWslDefault" {
         }
     }
 }
-

--- a/lib/wsl/core.Tests.ps1
+++ b/lib/wsl/core.Tests.ps1
@@ -7,7 +7,13 @@
 param()
 
 BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\wsl.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "Test-WslInstalled" {

--- a/lib/wsl/docker.Tests.ps1
+++ b/lib/wsl/docker.Tests.ps1
@@ -7,7 +7,13 @@
 param()
 
 BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\wsl.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "Test-WslDockerInstalled" {

--- a/lib/wsl/exec.Tests.ps1
+++ b/lib/wsl/exec.Tests.ps1
@@ -7,7 +7,13 @@
 param()
 
 BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\wsl.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "Invoke-WslDistroCommand" {

--- a/lib/wsl/install.Tests.ps1
+++ b/lib/wsl/install.Tests.ps1
@@ -7,7 +7,13 @@
 param()
 
 BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\wsl.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "Get-WslAvailableDistro" {

--- a/lib/wsl/manager.Tests.ps1
+++ b/lib/wsl/manager.Tests.ps1
@@ -6,8 +6,14 @@
 param()
 
 BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\commands.ps1"
     . "$PSScriptRoot\manager.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "Start-InteractiveMode" {

--- a/lib/wsl/manager.docker.Integration.Tests.ps1
+++ b/lib/wsl/manager.docker.Integration.Tests.ps1
@@ -64,7 +64,6 @@ Describe "WSL Manager Integration Tests" -Tag "Integration" {
         # Shutdown entire WSL subsystem to prevent systemd auto-restart race (SC-002)
         Write-Host "    Shutting down WSL subsystem before tests ..." -ForegroundColor Yellow
         Stop-WslSubsystem -Confirm:$false
-        Start-Sleep -Seconds 3
 
         # Always remove custom distro before tests (clean slate)
         if ($script:customDistroName -in $existingDistros) {
@@ -133,7 +132,6 @@ Describe "WSL Manager Integration Tests" -Tag "Integration" {
             # Shutdown WSL subsystem to prevent systemd auto-restart race (SC-002)
             Write-Host "Shutting down WSL subsystem before updating..." -ForegroundColor Yellow
             Stop-WslSubsystem -Confirm:$false
-            Start-Sleep -Seconds 3
 
             # Capture output from Update-WslDistro
             $output = Invoke-WslManager -Command "update" -Name $script:baseDistroName *>&1 | Out-String
@@ -160,7 +158,6 @@ Describe "WSL Manager Integration Tests" -Tag "Integration" {
             # Shutdown WSL subsystem to prevent systemd auto-restart race (SC-002)
             Write-Host "Shutting down WSL subsystem before cloning..." -ForegroundColor Yellow
             Stop-WslSubsystem -Confirm:$false
-            Start-Sleep -Seconds 3
 
             # Capture output from Copy-WslDistro
             $output = Invoke-WslManager -Command "clone" -Name $script:baseDistroName -TargetName $script:customDistroName *>&1 | Out-String

--- a/lib/wsl/manager.docker.Integration.Tests.ps1
+++ b/lib/wsl/manager.docker.Integration.Tests.ps1
@@ -31,6 +31,9 @@ param()
 
 Describe "WSL Manager Integration Tests" -Tag "Integration" {
     BeforeAll {
+        . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+        Start-SutIsolation
+
         $script:baseDistroName = "Debian"
         $script:customDistroName = "debian-custom-test"
         $script:outputCapture = @()
@@ -85,6 +88,8 @@ Describe "WSL Manager Integration Tests" -Tag "Integration" {
         }
 
         Write-Host "    Cleanup complete. Distributions preserved for exploratory testing." -ForegroundColor Green
+
+        Stop-SutIsolation
     }
 
     Context "Create Distribution" {

--- a/lib/wsl/manager.podman.Integration.Tests.ps1
+++ b/lib/wsl/manager.podman.Integration.Tests.ps1
@@ -62,7 +62,6 @@ Describe "WSL Manager Podman Integration Tests" -Tag "Integration" {
         # Shutdown entire WSL subsystem to prevent systemd auto-restart race (SC-002)
         Write-Host "    Shutting down WSL subsystem before tests ..." -ForegroundColor Yellow
         Stop-WslSubsystem -Confirm:$false
-        Start-Sleep -Seconds 3
 
         # Always remove test distro before tests (clean slate)
         if ($script:podmanTestDistroName -in $existingDistros) {
@@ -127,7 +126,6 @@ Describe "WSL Manager Podman Integration Tests" -Tag "Integration" {
             # Shutdown WSL subsystem to prevent systemd auto-restart race (SC-002)
             Write-Host "    Shutting down WSL subsystem before cloning..." -ForegroundColor Yellow
             Stop-WslSubsystem -Confirm:$false
-            Start-Sleep -Seconds 3
 
             $output = Invoke-WslManager -Command "clone" -Name $script:baseDistroName -TargetName $script:podmanTestDistroName *>&1 | Out-String
 

--- a/lib/wsl/manager.podman.Integration.Tests.ps1
+++ b/lib/wsl/manager.podman.Integration.Tests.ps1
@@ -30,6 +30,9 @@ param()
 
 Describe "WSL Manager Podman Integration Tests" -Tag "Integration" {
     BeforeAll {
+        . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+        Start-SutIsolation
+
         $script:baseDistroName = "Ubuntu"
         $script:podmanTestDistroName = "ubuntu-podman-test"
 
@@ -83,6 +86,8 @@ Describe "WSL Manager Podman Integration Tests" -Tag "Integration" {
         }
 
         Write-Host "    Cleanup complete. Distributions preserved for exploratory testing." -ForegroundColor Green
+
+        Stop-SutIsolation
     }
 
     Context "Create Base Distribution" {

--- a/lib/wsl/ops.Tests.ps1
+++ b/lib/wsl/ops.Tests.ps1
@@ -641,6 +641,68 @@ Describe "Stop-WslSubsystem" {
         }
     }
 
+    Context "When shutdown polling times out" {
+        BeforeEach {
+            Mock Get-WslDistroList {
+                @(
+                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
+                )
+            } -ParameterFilter { $Detailed }
+            Mock Invoke-CommandLine { }
+            Mock Write-Warning { }
+            Mock Write-Output { }
+            Mock Start-Sleep { }
+        }
+
+        It "Should throw timeout error when distros stay running" {
+            { Stop-WslSubsystem -Confirm:$false } | Should -Throw "*timed out*Still running*Debian*"
+        }
+
+        It "Should poll for 30 seconds before timing out" {
+            try { Stop-WslSubsystem -Confirm:$false } catch { $null = $_ }
+
+            Should -Invoke Start-Sleep -Times 30
+        }
+    }
+
+    Context "When shutdown requires multiple poll cycles" {
+        BeforeEach {
+            $script:pollCount = 0
+            Mock Get-WslDistroList {
+                $script:pollCount++
+                if ($script:pollCount -le 1) {
+                    @(
+                        [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
+                    )
+                } elseif ($script:pollCount -le 4) {
+                    @(
+                        [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
+                    )
+                } else {
+                    @(
+                        [PSCustomObject]@{ Name = "Debian"; State = "Stopped"; Version = 2; IsDefault = $true }
+                    )
+                }
+            } -ParameterFilter { $Detailed }
+            Mock Invoke-CommandLine { }
+            Mock Write-Warning { }
+            Mock Write-Output { }
+            Mock Start-Sleep { }
+        }
+
+        It "Should succeed after distros eventually stop" {
+            { Stop-WslSubsystem -Confirm:$false } | Should -Not -Throw
+        }
+
+        It "Should display success message after polling completes" {
+            Stop-WslSubsystem -Confirm:$false
+
+            Should -Invoke Write-Output -ParameterFilter {
+                $InputObject -like "*WSL subsystem has been shut down*"
+            }
+        }
+    }
+
     Context "When ShouldProcess is used" {
         BeforeEach {
             Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }

--- a/lib/wsl/ops.Tests.ps1
+++ b/lib/wsl/ops.Tests.ps1
@@ -7,7 +7,13 @@
 param()
 
 BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\wsl.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "Remove-WslDistro" {

--- a/lib/wsl/ops.Tests.ps1
+++ b/lib/wsl/ops.Tests.ps1
@@ -21,32 +21,28 @@ Describe "Remove-WslDistro" {
         It "Should throw an error" {
             Mock Assert-WslDistroExists { throw "Distribution '$DistroName' does not exist. Installed distributions: Ubuntu" }
 
-            { Remove-WslDistro -Name "Debian" } | Should -Throw "*does not exist*"
+            $act = { Remove-WslDistro -Name "Debian" }
+
+            $act | Should -Throw "*does not exist*"
         }
     }
 
     Context "When distribution is running" {
-        It "Should throw error with terminate instruction" {
-
+        BeforeEach {
             Mock Assert-WslDistroExists { }
             Mock Test-WslDistroRunning { $true }
             Mock Invoke-CommandLine { }
+        }
 
-            { Remove-WslDistro -Name "TestProject" -Confirm:$false } | Should -Throw "*is running*Stop it first with*wsl --terminate TestProject*"
+        It "Should throw error with terminate instruction" {
+            $act = { Remove-WslDistro -Name "TestProject" -Confirm:$false }
+
+            $act | Should -Throw "*is running*Stop it first with*wsl --terminate TestProject*"
         }
 
         It "Should not call unregister when distribution is running" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Test-WslDistroRunning { $true }
-            Mock Invoke-CommandLine { }
-
-            try {
-                Remove-WslDistro -Name "TestProject" -Confirm:$false
-            }
-            catch {
-                $null = $_
-            }
+            try { Remove-WslDistro -Name "TestProject" -Confirm:$false }
+            catch { $null = $_ }
 
             Should -Invoke Invoke-CommandLine -Times 0 -ParameterFilter {
                 $CommandLine -like "*wsl.exe --unregister*"
@@ -55,12 +51,13 @@ Describe "Remove-WslDistro" {
     }
 
     Context "When user cancels confirmation" {
-        It "Should not remove distribution" {
-
+        BeforeEach {
             Mock Assert-WslDistroExists { }
             Mock Test-WslDistroRunning { $false }
             Mock Invoke-CommandLine {}
+        }
 
+        It "Should not remove distribution" {
             Remove-WslDistro -Name "Debian" -WhatIf
 
             Should -Invoke Invoke-CommandLine -Times 0
@@ -68,40 +65,34 @@ Describe "Remove-WslDistro" {
     }
 
     Context "When user confirms removal" {
-        It "Should remove distribution using wsl.exe --unregister" {
-
+        BeforeEach {
             Mock Assert-WslDistroExists { }
             Mock Test-WslDistroRunning { $false }
             Mock Invoke-CommandLine {}
+        }
 
+        It "Should remove distribution using wsl.exe --unregister" {
             Remove-WslDistro -Name "Debian" -Confirm:$false
 
             Should -Invoke Invoke-CommandLine -ParameterFilter { $CommandLine -eq "wsl.exe --unregister Debian" }
         }
     }
 
-    Context "When Force parameter is used" {
-        It "Should skip confirmation and remove distribution" {
-
+    Context "When unregister command fails" {
+        BeforeEach {
             Mock Assert-WslDistroExists { }
             Mock Test-WslDistroRunning { $false }
-            Mock Invoke-CommandLine {}
-
-            Remove-WslDistro -Name "Debian" -Confirm:$false
-
-            Should -Invoke Invoke-CommandLine -ParameterFilter { $CommandLine -eq "wsl.exe --unregister Debian" }
         }
 
         It "Should throw error when wsl command fails" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Test-WslDistroRunning { $false }
             Mock Invoke-CommandLine {
                 $global:LASTEXITCODE = 1
                 throw "Command line call `"wsl.exe --unregister Debian`" failed with exit code 1"
             }
 
-            { Remove-WslDistro -Name "Debian" -Confirm:$false } | Should -Throw "*failed with exit code 1*"
+            $act = { Remove-WslDistro -Name "Debian" -Confirm:$false }
+
+            $act | Should -Throw "*failed with exit code 1*"
         }
     }
 }
@@ -111,44 +102,40 @@ Describe "Copy-WslDistro" {
         It "Should throw an error" {
             Mock Assert-WslDistroExists { throw "Distribution '$DistroName' does not exist. Installed distributions: Ubuntu" }
 
-            { Copy-WslDistro -SourceName "Debian" -TargetName "MyDebian" } | Should -Throw "*does not exist*"
+            $act = { Copy-WslDistro -SourceName "Debian" -TargetName "MyDebian" }
+
+            $act | Should -Throw "*does not exist*"
         }
     }
 
     Context "When target distribution already exists" {
         It "Should throw an error" {
-
             Mock Assert-WslDistroExists { }
             Mock Assert-WslDistroNotExists { throw "Distribution '$($DistroName.Trim())' already exists." }
 
-            { Copy-WslDistro -SourceName "Debian" -TargetName "MyDebian" } | Should -Throw "*already exists*"
+            $act = { Copy-WslDistro -SourceName "Debian" -TargetName "MyDebian" }
+
+            $act | Should -Throw "*already exists*"
         }
     }
 
     Context "When source distribution is running" {
-        It "Should throw error with terminate instruction" {
-
+        BeforeEach {
             Mock Assert-WslDistroExists { }
             Mock Assert-WslDistroNotExists { }
             Mock Test-WslDistroRunning { $true }
             Mock Invoke-CommandLine { }
+        }
 
-            { Copy-WslDistro -SourceName "Debian" -TargetName "MyProject" -Confirm:$false } | Should -Throw "*is running*Stop it first with*wsl --terminate Debian*"
+        It "Should throw error with terminate instruction" {
+            $act = { Copy-WslDistro -SourceName "Debian" -TargetName "MyProject" -Confirm:$false }
+
+            $act | Should -Throw "*is running*Stop it first with*wsl --terminate Debian*"
         }
 
         It "Should not call export when source distribution is running" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Assert-WslDistroNotExists { }
-            Mock Test-WslDistroRunning { $true }
-            Mock Invoke-CommandLine { }
-
-            try {
-                Copy-WslDistro -SourceName "Debian" -TargetName "MyProject" -Confirm:$false
-            }
-            catch {
-                $null = $_
-            }
+            try { Copy-WslDistro -SourceName "Debian" -TargetName "MyProject" -Confirm:$false }
+            catch { $null = $_ }
 
             Should -Invoke Invoke-CommandLine -Times 0 -ParameterFilter {
                 $CommandLine -like "*wsl.exe --export*"
@@ -218,16 +205,6 @@ Describe "Copy-WslDistro" {
         }
 
         It "Should display how to start the cloned distribution" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Assert-WslDistroNotExists { }
-            Mock Test-WslDistroRunning { $false }
-            Mock Invoke-CommandLine {}
-            Mock Test-Path { $false } -ParameterFilter { $Path -notlike "*temp*.tar" }
-            Mock Test-Path { $true } -ParameterFilter { $Path -like "*temp*.tar" }
-            Mock New-Item {}
-            Mock Remove-Item {}
-
             $output = Copy-WslDistro -SourceName "Ubuntu" -TargetName "MyUbuntu" -Confirm:$false 6>&1
 
             $output -join ' ' | Should -Match "To start: wsl.exe --distribution MyUbuntu"
@@ -252,42 +229,39 @@ Describe "Copy-WslDistro" {
     }
 
     Context "When export fails" {
-        It "Should not attempt import and should clean up" {
-
+        BeforeEach {
             Mock Assert-WslDistroExists { }
             Mock Assert-WslDistroNotExists { }
             Mock Test-WslDistroRunning { $false }
-            Mock Invoke-CommandLine { throw "Export failed" } -ParameterFilter { $CommandLine -like "wsl.exe --export *" }
             Mock Test-Path { $true }
             Mock Remove-Item {}
+        }
 
-            { Copy-WslDistro -SourceName "Debian" -TargetName "MyDebian" -Confirm:$false } | Should -Throw
+        It "Should not attempt import and should clean up" {
+            Mock Invoke-CommandLine { throw "Export failed" } -ParameterFilter { $CommandLine -like "wsl.exe --export *" }
 
+            $act = { Copy-WslDistro -SourceName "Debian" -TargetName "MyDebian" -Confirm:$false }
+
+            $act | Should -Throw
             Should -Invoke Invoke-CommandLine -ParameterFilter { $CommandLine -like "wsl.exe --import *" } -Times 0
             Should -Invoke Remove-Item
         }
 
         It "Should clean up temp file when import fails" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Assert-WslDistroNotExists { }
-            Mock Test-WslDistroRunning { $false }
             Mock Invoke-CommandLine {} -ParameterFilter { $CommandLine -like "wsl.exe --export *" }
             Mock Invoke-CommandLine {
                 $global:LASTEXITCODE = 1
                 throw "Command line call failed with exit code 1"
             } -ParameterFilter { $CommandLine -like "wsl.exe --import *" }
-            Mock Test-Path { $true }
-            Mock Remove-Item {}
 
-            { Copy-WslDistro -SourceName "Debian" -TargetName "MyDebian" -Confirm:$false } | Should -Throw
+            $act = { Copy-WslDistro -SourceName "Debian" -TargetName "MyDebian" -Confirm:$false }
 
-            # Verify temp file cleanup still happens
+            $act | Should -Throw
             Should -Invoke Remove-Item
         }
     }
 
-    Context "When testing boundary conditions" {
+    Context "When names contain special characters or whitespace" {
         BeforeEach {
 
             Mock Assert-WslDistroExists { }
@@ -358,75 +332,75 @@ Describe "Update-WslDistro" {
         It "Should throw an error" {
             Mock Assert-WslDistroExists { throw "Distribution '$DistroName' does not exist. Installed distributions: Ubuntu" }
 
-            { Update-WslDistro -Name "Debian" } | Should -Throw "*does not exist*"
+            $act = { Update-WslDistro -Name "Debian" }
+
+            $act | Should -Throw "*does not exist*"
         }
     }
 
     Context "When distribution is running" {
-        It "Should throw error with terminate instruction" {
-
+        BeforeEach {
             Mock Assert-WslDistroExists { }
             Mock Test-WslDistroRunning { $true }
             Mock Get-WslDistroType { "debian" }
             Mock Invoke-WslDistroCommand { }
+        }
 
-            { Update-WslDistro -Name "Debian" -Confirm:$false } | Should -Throw "*is running*Stop it first with*wsl --terminate Debian*"
+        It "Should throw error with terminate instruction" {
+            $act = { Update-WslDistro -Name "Debian" -Confirm:$false }
+
+            $act | Should -Throw "*is running*Stop it first with*wsl --terminate Debian*"
         }
 
         It "Should not call apt update when distribution is running" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Test-WslDistroRunning { $true }
-            Mock Get-WslDistroType { "debian" }
-            Mock Invoke-WslDistroCommand { }
-
-            try {
-                Update-WslDistro -Name "Debian" -Confirm:$false
-            }
-            catch {
-                $null = $_
-            }
+            try { Update-WslDistro -Name "Debian" -Confirm:$false }
+            catch { $null = $_ }
 
             Should -Invoke Invoke-WslDistroCommand -Times 0
         }
     }
 
     Context "When distribution is not Debian/Ubuntu" {
-        It "Should throw error for Arch distribution" {
-
+        BeforeEach {
             Mock Assert-WslDistroExists { }
             Mock Test-WslDistroRunning { $false }
+        }
+
+        It "Should throw error for Arch distribution" {
             Mock Get-WslDistroType { "arch" }
 
-            { Update-WslDistro -Name "Arch" -Confirm:$false } | Should -Throw "*not a Debian/Ubuntu distribution*"
+            $act = { Update-WslDistro -Name "Arch" -Confirm:$false }
+
+            $act | Should -Throw "*not a Debian/Ubuntu distribution*"
         }
 
         It "Should throw error for RHEL family" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Test-WslDistroRunning { $false }
             Mock Get-WslDistroType { "rhel" }
 
-            { Update-WslDistro -Name "Fedora" -Confirm:$false } | Should -Throw "*not a Debian/Ubuntu distribution*"
+            $act = { Update-WslDistro -Name "Fedora" -Confirm:$false }
+
+            $act | Should -Throw "*not a Debian/Ubuntu distribution*"
         }
 
         It "Should throw error for unknown distribution" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Test-WslDistroRunning { $false }
             Mock Get-WslDistroType { "unknown" }
 
-            { Update-WslDistro -Name "CustomLinux" -Confirm:$false } | Should -Throw "*not a Debian/Ubuntu distribution*"
+            $act = { Update-WslDistro -Name "CustomLinux" -Confirm:$false }
+
+            $act | Should -Throw "*not a Debian/Ubuntu distribution*"
         }
     }
 
     Context "When updating Debian/Ubuntu distributions" {
-        It "Should update Debian distribution successfully" {
-
+        BeforeEach {
             Mock Assert-WslDistroExists { }
             Mock Test-WslDistroRunning { $false }
-            Mock Get-WslDistroType { "debian" }
             Mock Invoke-WslDistroCommand { }
+            Mock Write-Output { }
+        }
+
+        It "Should update Debian distribution successfully" {
+            Mock Get-WslDistroType { "debian" }
 
             Update-WslDistro -Name "Debian" -Confirm:$false
 
@@ -436,11 +410,7 @@ Describe "Update-WslDistro" {
         }
 
         It "Should update Ubuntu distribution successfully" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Test-WslDistroRunning { $false }
             Mock Get-WslDistroType { "ubuntu" }
-            Mock Invoke-WslDistroCommand { }
 
             Update-WslDistro -Name "Ubuntu" -Confirm:$false
 
@@ -450,12 +420,7 @@ Describe "Update-WslDistro" {
         }
 
         It "Should display progress message" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Test-WslDistroRunning { $false }
             Mock Get-WslDistroType { "debian" }
-            Mock Invoke-WslDistroCommand { }
-            Mock Write-Output { }
 
             Update-WslDistro -Name "Debian" -Confirm:$false
 
@@ -465,12 +430,7 @@ Describe "Update-WslDistro" {
         }
 
         It "Should display success message" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Test-WslDistroRunning { $false }
             Mock Get-WslDistroType { "debian" }
-            Mock Invoke-WslDistroCommand { }
-            Mock Write-Output { }
 
             Update-WslDistro -Name "Debian" -Confirm:$false
 
@@ -480,11 +440,7 @@ Describe "Update-WslDistro" {
         }
 
         It "Should trim whitespace from distribution name" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Test-WslDistroRunning { $false }
             Mock Get-WslDistroType { "debian" }
-            Mock Invoke-WslDistroCommand { }
 
             Update-WslDistro -Name "  Debian  " -Confirm:$false
 
@@ -494,9 +450,8 @@ Describe "Update-WslDistro" {
         }
     }
 
-    Context "When ShouldProcess is used" {
-        It "Should skip update when user cancels confirmation" {
-
+    Context "When user cancels with -WhatIf" {
+        It "Should skip update" {
             Mock Assert-WslDistroExists { }
             Mock Test-WslDistroRunning { $false }
             Mock Get-WslDistroType { "debian" }
@@ -509,31 +464,23 @@ Describe "Update-WslDistro" {
     }
 
     Context "When update command fails" {
-        It "Should throw error when apt command fails" {
-
-            Mock Assert-WslDistroExists { }
-            Mock Test-WslDistroRunning { $false }
-            Mock Get-WslDistroType { "debian" }
-            Mock Invoke-WslDistroCommand { throw "apt upgrade failed" }
-
-            { Update-WslDistro -Name "Debian" -Confirm:$false } | Should -Throw "*apt upgrade failed*"
-        }
-
-        It "Should not display success message when update fails" {
-
+        BeforeEach {
             Mock Assert-WslDistroExists { }
             Mock Test-WslDistroRunning { $false }
             Mock Get-WslDistroType { "debian" }
             Mock Invoke-WslDistroCommand { throw "apt upgrade failed" }
             Mock Write-Output { }
+        }
 
-            try {
-                Update-WslDistro -Name "Debian" -Confirm:$false
-            }
-            catch {
-                # Expected to throw - suppressing error for test verification
-                $null = $_
-            }
+        It "Should throw error when apt command fails" {
+            $act = { Update-WslDistro -Name "Debian" -Confirm:$false }
+
+            $act | Should -Throw "*apt upgrade failed*"
+        }
+
+        It "Should not display success message when update fails" {
+            try { Update-WslDistro -Name "Debian" -Confirm:$false }
+            catch { $null = $_ }
 
             Should -Invoke Write-Output -ParameterFilter {
                 $InputObject -like "*Successfully*"
@@ -541,9 +488,11 @@ Describe "Update-WslDistro" {
         }
     }
 
-    Context "Parameter validation" {
+    Context "When given invalid input" {
         It "Should throw when Name is empty" {
-            { Update-WslDistro -Name "" } | Should -Throw
+            $act = { Update-WslDistro -Name "" }
+
+            $act | Should -Throw
         }
     }
 }
@@ -655,11 +604,14 @@ Describe "Stop-WslSubsystem" {
         }
 
         It "Should throw timeout error when distros stay running" {
-            { Stop-WslSubsystem -Confirm:$false } | Should -Throw "*timed out*Still running*Debian*"
+            $act = { Stop-WslSubsystem -Confirm:$false }
+
+            $act | Should -Throw "*timed out*Still running*Debian*"
         }
 
         It "Should poll for 30 seconds before timing out" {
-            try { Stop-WslSubsystem -Confirm:$false } catch { $null = $_ }
+            try { Stop-WslSubsystem -Confirm:$false }
+            catch { $null = $_ }
 
             Should -Invoke Start-Sleep -Times 30
         }
@@ -728,7 +680,9 @@ Describe "Stop-WslSubsystem" {
         }
 
         It "Should throw error when wsl command fails" {
-            { Stop-WslSubsystem -Confirm:$false } | Should -Throw "*failed with exit code 1*"
+            $act = { Stop-WslSubsystem -Confirm:$false }
+
+            $act | Should -Throw "*failed with exit code 1*"
         }
     }
 

--- a/lib/wsl/ops.Tests.ps1
+++ b/lib/wsl/ops.Tests.ps1
@@ -551,11 +551,20 @@ Describe "Update-WslDistro" {
 Describe "Stop-WslSubsystem" {
     Context "When distributions are running" {
         BeforeEach {
+            $script:shutdownCallCount = 0
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
-                    [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
-                )
+                $script:shutdownCallCount++
+                if ($script:shutdownCallCount -le 1) {
+                    @(
+                        [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
+                        [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
+                    )
+                } else {
+                    @(
+                        [PSCustomObject]@{ Name = "Debian"; State = "Stopped"; Version = 2; IsDefault = $true },
+                        [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
+                    )
+                }
             } -ParameterFilter { $Detailed }
             Mock Invoke-CommandLine { }
             Mock Write-Warning { }

--- a/lib/wsl/ops.ps1
+++ b/lib/wsl/ops.ps1
@@ -189,6 +189,24 @@ function Stop-WslSubsystem {
     if ($PSCmdlet.ShouldProcess("WSL subsystem", "Shutdown all distributions and the WSL2 VM")) {
         Write-Output "Shutting down WSL subsystem ..."
         Invoke-CommandLine -CommandLine "wsl.exe --shutdown"
+
+        # Poll until all distributions are actually stopped.
+        # wsl.exe --shutdown returns before the VM has fully terminated,
+        # causing race conditions if callers proceed immediately.
+        $maxWaitSeconds = 30
+        $elapsed = 0
+        while ($elapsed -lt $maxWaitSeconds) {
+            $still = @(Get-WslDistroList -Detailed | Where-Object { $_.State -eq 'Running' })
+            if ($still.Count -eq 0) { break }
+            Start-Sleep -Seconds 1
+            $elapsed++
+        }
+
+        if ($elapsed -ge $maxWaitSeconds) {
+            $names = ($still | ForEach-Object { $_.Name }) -join ', '
+            throw "WSL shutdown timed out after ${maxWaitSeconds}s. Still running: $names"
+        }
+
         Write-Output "WSL subsystem has been shut down."
     }
     else {

--- a/lib/wsl/podman.Tests.ps1
+++ b/lib/wsl/podman.Tests.ps1
@@ -7,7 +7,13 @@
 param()
 
 BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\wsl.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "Test-WslPodmanInstalled" {

--- a/lib/wsl/podman.Tests.ps1
+++ b/lib/wsl/podman.Tests.ps1
@@ -267,6 +267,7 @@ Describe "Install-WslPodman" {
             Mock Invoke-WslDistroCommand { "debian`nbookworm`namd64" } -ParameterFilter { $Command -like "*. /etc/os-release*" }
             Mock Invoke-WslDistroScript { $global:LASTEXITCODE = 0; return 0 }
             Mock Test-Path { $true }
+            Mock Stop-WslDistro { }
         }
 
         It "Should not throw when Podman is already installed" {
@@ -311,6 +312,7 @@ Describe "Install-WslPodman" {
             Mock Invoke-WslDistroCommand { "debian`nbookworm`namd64" } -ParameterFilter { $Command -like "*. /etc/os-release*echo*VERSION_CODENAME*dpkg --print-architecture*" }
             Mock Invoke-WslDistroScript { $global:LASTEXITCODE = 0; return 0 }
             Mock Test-Path { $true }
+            Mock Stop-WslDistro { }
         }
 
         It "Should support -WhatIf parameter" {
@@ -347,6 +349,7 @@ Describe "Install-WslPodman" {
             Mock Invoke-WslDistroCommand { "debian`nbookworm`namd64" } -ParameterFilter { $Command -like "*. /etc/os-release*echo*VERSION_CODENAME*dpkg --print-architecture*" }
             Mock Invoke-WslDistroScript { $global:LASTEXITCODE = 0; return 0 }
             Mock Test-Path { $true }
+            Mock Stop-WslDistro { }
         }
 
         It "Should call Invoke-WslDistroScript with install-podman.sh" {
@@ -475,6 +478,7 @@ Describe "Install-WslPodman" {
             Mock Invoke-WslDistroCommand { "debian`nbookworm`namd64" } -ParameterFilter { $Command -like "*. /etc/os-release*echo*VERSION_CODENAME*dpkg --print-architecture*" }
             Mock Invoke-WslDistroScript { $global:LASTEXITCODE = 0; return 0 }
             Mock Test-Path { $true }
+            Mock Stop-WslDistro { }
         }
 
         It "Should configure systemd if not already configured" {

--- a/lib/wsl/proxy.Tests.ps1
+++ b/lib/wsl/proxy.Tests.ps1
@@ -7,15 +7,17 @@
 param()
 
 BeforeAll {
-    . "$PSScriptRoot\wsl.ps1"
-
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
     # Source setProxy.ps1 in library mode so its functions exist for mocking
     $env:SETPROXY_LIBRARY_MODE = '1'
+    Start-SutIsolation
+    . "$PSScriptRoot\wsl.ps1"
     . "$PSScriptRoot\..\..\tools\proxy\setProxy.ps1"
 }
 
 AfterAll {
     Remove-Item Env:\SETPROXY_LIBRARY_MODE -ErrorAction SilentlyContinue
+    Stop-SutIsolation
 }
 
 Describe "Install-WslProxy" {

--- a/lib/wsl/user.Tests.ps1
+++ b/lib/wsl/user.Tests.ps1
@@ -7,7 +7,13 @@
 param()
 
 BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\wsl.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "New-WslUser" {

--- a/lib/wsl/wsl.Integration.Tests.ps1
+++ b/lib/wsl/wsl.Integration.Tests.ps1
@@ -9,6 +9,8 @@ param()
 
 Describe "WSL Library Integration Tests" -Tag "Integration" {
     BeforeAll {
+        . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+        Start-SutIsolation
         $wslScript = Join-Path $PSScriptRoot ".\wsl.ps1"
         if (Test-Path $wslScript) {
             . $wslScript
@@ -72,5 +74,9 @@ Describe "WSL Library Integration Tests" -Tag "Integration" {
                  $isWsl2 | Should -Be $expected
              }
         }
+    }
+
+    AfterAll {
+        Stop-SutIsolation
     }
 }

--- a/lib/wsl/wsl.Tests.ps1
+++ b/lib/wsl/wsl.Tests.ps1
@@ -4,7 +4,13 @@
 #>
 
 BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\wsl.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "Module Structure - Backward Compatibility" {

--- a/test/bin/lib/TestConfiguration.Tests.ps1
+++ b/test/bin/lib/TestConfiguration.Tests.ps1
@@ -3,11 +3,13 @@
 
 Describe "Test Configuration Logic" {
     BeforeAll {
+        . "$PSScriptRoot\TestIsolation.ps1"
         $libPath = Join-Path $PSScriptRoot "TestConfiguration.ps1"
         if (-not (Test-Path $libPath)) {
             Throw "Script not found at $libPath"
         }
-        . "$libPath"
+        Start-SutIsolation
+        . $libPath
 
         # Setup temporary test directory structure
         $TestDrive = Join-Path $PSScriptRoot "temp_test_structure"
@@ -32,6 +34,7 @@ Describe "Test Configuration Logic" {
         if ($script:TestRepoRoot -and (Test-Path $script:TestRepoRoot)) {
             Remove-Item $script:TestRepoRoot -Recurse -Force -ErrorAction SilentlyContinue
         }
+        Stop-SutIsolation
     }
 
     Context "Get-TestConfiguration Path Resolution" {

--- a/test/bin/lib/TestIsolation.ps1
+++ b/test/bin/lib/TestIsolation.ps1
@@ -1,0 +1,55 @@
+﻿<#
+.DESCRIPTION
+    Test isolation helpers for Pester tests.
+    Prevents cross-file function leakage when dot-sourcing libraries.
+    This file is meant to be dot-sourced in BeforeAll blocks.
+
+    Usage:
+        BeforeAll {
+            . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+            Start-SutIsolation
+            . "$PSScriptRoot\module.ps1"
+        }
+
+        AfterAll {
+            Stop-SutIsolation
+        }
+#>
+
+function Start-SutIsolation {
+    <#
+    .SYNOPSIS
+        Snapshots current functions before dot-sourcing scripts under test.
+
+    .DESCRIPTION
+        Call this BEFORE dot-sourcing any library scripts. It records which
+        functions exist so that Stop-SutIsolation can clean up the ones that were added.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Snapshots in-process state only, no system changes')]
+    [CmdletBinding()]
+    param()
+
+    $script:_existingFunctions = @(Get-ChildItem Function:).Name
+}
+
+function Stop-SutIsolation {
+    <#
+    .SYNOPSIS
+        Removes functions added after Start-SutIsolation to prevent cross-file test leakage.
+
+    .DESCRIPTION
+        Compares current functions against the snapshot taken by Start-SutIsolation
+        and removes any that were added by dot-sourcing.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Cleans up in-process test state only, no system changes')]
+    [CmdletBinding()]
+    param()
+
+    if ($null -ne $script:_existingFunctions) {
+        $addedFunctions = @(Get-ChildItem Function:).Name |
+            Where-Object { $_ -notin $script:_existingFunctions }
+        $addedFunctions | ForEach-Object {
+            Remove-Item "Function:\$_" -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/test/bin/testrunner.Tests.ps1
+++ b/test/bin/testrunner.Tests.ps1
@@ -10,7 +10,13 @@
 #>
 
 BeforeAll {
+    . "$PSScriptRoot\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\..\..\test\bin\testrunner.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe 'ConvertTo-RelativeJUnitXml' {

--- a/test/bin/testrunner.ps1
+++ b/test/bin/testrunner.ps1
@@ -490,5 +490,6 @@ if ($MyInvocation.InvocationName -ne '.') {
         $ErrorActionPreference = 'SilentlyContinue'
     }
 
-    Exit $exitCode
+    $host.SetShouldExit($exitCode)
+    exit $exitCode
 }

--- a/tools/claude-code/install-claude-code.bat
+++ b/tools/claude-code/install-claude-code.bat
@@ -1,2 +1,2 @@
 @echo off
-pwsh -ExecutionPolicy Bypass -File %~dp0install-claude-code.ps1 || exit /b 1
+powershell -ExecutionPolicy Bypass -File %~dp0install-claude-code.ps1 || exit /b 1

--- a/tools/flow-launcher/configure-program-plugin.Tests.ps1
+++ b/tools/flow-launcher/configure-program-plugin.Tests.ps1
@@ -6,9 +6,14 @@
 #>
 
 BeforeAll {
-    # Source the script under test
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    Start-SutIsolation
     . "$PSScriptRoot\configure-program-plugin.ps1"
     . "$PSScriptRoot\..\..\lib\utils\utils.ps1"
+}
+
+AfterAll {
+    Stop-SutIsolation
 }
 
 Describe "Get-ProgramPluginSettingsPath" {

--- a/tools/flow-launcher/configure-program-plugin.bat
+++ b/tools/flow-launcher/configure-program-plugin.bat
@@ -1,2 +1,2 @@
 @echo off
-pwsh -ExecutionPolicy Bypass -File %~dp0configure-program-plugin.ps1 %*
+powershell -ExecutionPolicy Bypass -File %~dp0configure-program-plugin.ps1 %*

--- a/tools/flow-launcher/install-flow-launcher.bat
+++ b/tools/flow-launcher/install-flow-launcher.bat
@@ -1,2 +1,2 @@
 @echo off
-pwsh -ExecutionPolicy Bypass -File %~dp0install-flow-launcher.ps1 %*
+powershell -ExecutionPolicy Bypass -File %~dp0install-flow-launcher.ps1 %*

--- a/tools/github-copilot/install-github-copilot.bat
+++ b/tools/github-copilot/install-github-copilot.bat
@@ -1,2 +1,1 @@
-@echo off
-powershell -ExecutionPolicy Bypass -File %~dp0..\install\install-npm-global.ps1 -PackageName "@github/copilot" -CheckCommand "copilot" || exit /b 1
+powershell -ExecutionPolicy Bypass -File %~dp0..\..\lib\install\install-npm-global.ps1 -PackageName "@github/copilot" -CheckCommand "copilot" || exit /b 1

--- a/tools/github-copilot/install-github-copilot.bat
+++ b/tools/github-copilot/install-github-copilot.bat
@@ -1,2 +1,2 @@
 @echo off
-pwsh -ExecutionPolicy Bypass -File %~dp0..\install\install-npm-global.ps1 -PackageName "@github/copilot" -CheckCommand "copilot" || exit /b 1
+powershell -ExecutionPolicy Bypass -File %~dp0..\install\install-npm-global.ps1 -PackageName "@github/copilot" -CheckCommand "copilot" || exit /b 1

--- a/tools/proxy/setProxy.Tests.ps1
+++ b/tools/proxy/setProxy.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 #Requires -Modules @{ModuleName = 'Pester'; ModuleVersion = '5.2.0'}
 
 <#
@@ -14,6 +14,7 @@
 param()
 
 BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
     # Set library mode to prevent auto-execution when dot-sourcing
     $env:SETPROXY_LIBRARY_MODE = '1'
 
@@ -23,7 +24,7 @@ BeforeAll {
     $script:OriginalNoProxy = $Env:NO_PROXY
     $script:OriginalDefaultWebProxy = [System.Net.WebRequest]::DefaultWebProxy
 
-    # Source the script to get access to functions
+    Start-SutIsolation
     . "$PSScriptRoot\setProxy.ps1"
 }
 
@@ -52,6 +53,8 @@ AfterAll {
 
     # Restore DefaultWebProxy
     [System.Net.WebRequest]::DefaultWebProxy = $script:OriginalDefaultWebProxy
+
+    Stop-SutIsolation
 }
 
 Describe "Get-InternetSettingsFromRegistry" {

--- a/tools/pslib/wsl/obsolete.md
+++ b/tools/pslib/wsl/obsolete.md
@@ -1,0 +1,7 @@
+# Obsolete
+
+The wsl-manager entry point has moved to `tools/wsl-manager/`.
+
+These wrapper scripts exist only for backward compatibility with old
+documentation and external scripts. New references should point to
+`tools/wsl-manager/wsl-manager.{bat,ps1}` directly.

--- a/tools/pslib/wsl/wsl-manager.bat
+++ b/tools/pslib/wsl/wsl-manager.bat
@@ -1,0 +1,3 @@
+@echo off
+rem Wrapper — this file has moved to tools\wsl-manager\wsl-manager.bat
+"%~dp0..\..\wsl-manager\wsl-manager.bat" %*

--- a/tools/pslib/wsl/wsl-manager.ps1
+++ b/tools/pslib/wsl/wsl-manager.ps1
@@ -1,0 +1,3 @@
+﻿#Requires -Version 5.1
+# Wrapper — this file has moved to tools/wsl-manager/wsl-manager.ps1
+& "$PSScriptRoot\..\..\wsl-manager\wsl-manager.ps1" @args


### PR DESCRIPTION
## Summary
- Close SC-015 in backlog after project structure reorganization
- Enforce PS 5.1 compatibility: fix 5 batch wrappers using `pwsh` instead of `powershell`
- Harmonize status fields across all 34 backlog items to canonical format
- Fix wrong `.ps1` path in GitHub Copilot wrapper
- Add backward-compat wrappers at old `tools/pslib/wsl/` location for legacy docs/scripts

## Test plan
- [ ] Verify `tools/pslib/wsl/wsl-manager.bat` forwards to `tools/wsl-manager/wsl-manager.bat`
- [ ] Verify `tools/pslib/wsl/wsl-manager.ps1` forwards to `tools/wsl-manager/wsl-manager.ps1`
- [ ] Verify all `.bat` wrappers invoke `powershell` (not `pwsh`) for PS 5.1 compatibility

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>