### PR TITLE
feat: modernize WSL Manager TUI with PwshSpectreConsole (SC-016)

### DIFF
--- a/.claude/skills/powershell-test-exec/SKILL.md
+++ b/.claude/skills/powershell-test-exec/SKILL.md
@@ -7,6 +7,10 @@ description: "This project's test execution skill. Execute Pester tests for Powe
 
 This project's test execution skill. Runs Pester tests for PowerShell code.
 
+## CRITICAL: Always Use testrunner.ps1
+
+**NEVER call `Invoke-Pester` directly.** Always use `testrunner.ps1` to run tests. The testrunner includes linting (PSScriptAnalyzer), JUnit report generation, and other checks that `Invoke-Pester` alone skips. Running `Invoke-Pester` directly will miss failures.
+
 ## Quick Reference
 
 ### Standard Test Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,10 @@ tools/wsl-manager/
 
 - **No em-dashes** (`—`) in any `.md` file. Use a colon (`:`) to introduce explanations, a semicolon (`;`) to join independent clauses, or a normal dash (`-`) for asides and parenthetical remarks.
 
+## Backlog Lifecycle
+
+When starting work on a backlog item, update its status to **In Progress** and move it in the README index before committing implementation changes. When a subtask or the full item is completed, update status accordingly per the closing checklist in `docs/backlog/README.md`. Backlog updates are part of the implementation commit, not a separate afterthought.
+
 ## Coding Guidelines
 
 - TDD

--- a/bin/install.Tests.ps1
+++ b/bin/install.Tests.ps1
@@ -207,6 +207,59 @@ Describe 'Install-OptionalToolset' {
     }
 }
 
+Describe 'Install-PowerShellModule' {
+    BeforeAll {
+        . $script:installScript -InPlace
+    }
+
+    Context 'when PwshSpectreConsole is already installed' {
+        BeforeAll {
+            Mock Get-InstalledModule { return @{ Name = 'PwshSpectreConsole'; Version = '2.1.0' } } -ParameterFilter { $Name -eq 'PwshSpectreConsole' }
+            Mock Install-Module {}
+        }
+
+        It 'skips installation' {
+            Install-PowerShellModule
+            Should -Not -Invoke Install-Module
+        }
+    }
+
+    Context 'when PwshSpectreConsole is not installed' {
+        BeforeAll {
+            Mock Get-InstalledModule { $null } -ParameterFilter { $Name -eq 'PwshSpectreConsole' }
+            Mock Get-PackageProvider { return @{ Name = 'NuGet' } } -ParameterFilter { $Name -eq 'NuGet' }
+            Mock Install-Module {}
+        }
+
+        It 'installs PwshSpectreConsole from PSGallery' {
+            Install-PowerShellModule
+            Should -Invoke Install-Module -Times 1 -ParameterFilter {
+                $Name -eq 'PwshSpectreConsole' -and
+                $Repository -eq 'PSGallery' -and
+                $Scope -eq 'CurrentUser'
+            }
+        }
+    }
+
+    Context 'when NuGet provider is missing' {
+        BeforeAll {
+            Mock Get-InstalledModule { $null } -ParameterFilter { $Name -eq 'PwshSpectreConsole' }
+            Mock Get-PackageProvider { $null } -ParameterFilter { $Name -eq 'NuGet' }
+            Mock Install-PackageProvider {}
+            Mock Install-Module {}
+        }
+
+        It 'installs NuGet provider before the module' {
+            Install-PowerShellModule
+            Should -Invoke Install-PackageProvider -Times 1 -ParameterFilter {
+                $Name -eq 'NuGet' -and
+                $Scope -eq 'CurrentUser'
+            }
+            Should -Invoke Install-Module -Times 1
+        }
+    }
+}
+
 Describe 'Copy-Config' {
     BeforeAll {
         . $script:installScript -InPlace

--- a/bin/install.Tests.ps1
+++ b/bin/install.Tests.ps1
@@ -207,7 +207,7 @@ Describe 'Install-OptionalToolset' {
     }
 }
 
-Describe 'Install-PowerShellModule' {
+Describe 'Install-PwshSpectreDependency' {
     BeforeAll {
         . $script:installScript -InPlace
     }
@@ -216,10 +216,11 @@ Describe 'Install-PowerShellModule' {
         BeforeAll {
             Mock Get-InstalledModule { return @{ Name = 'PwshSpectreConsole'; Version = '2.1.0' } } -ParameterFilter { $Name -eq 'PwshSpectreConsole' }
             Mock Install-Module {}
+            Mock Write-Host {}
         }
 
         It 'skips installation' {
-            Install-PowerShellModule
+            Install-PwshSpectreDependency
             Should -Not -Invoke Install-Module
         }
     }
@@ -229,10 +230,11 @@ Describe 'Install-PowerShellModule' {
             Mock Get-InstalledModule { $null } -ParameterFilter { $Name -eq 'PwshSpectreConsole' }
             Mock Get-PackageProvider { return @{ Name = 'NuGet' } } -ParameterFilter { $Name -eq 'NuGet' }
             Mock Install-Module {}
+            Mock Write-Host {}
         }
 
         It 'installs PwshSpectreConsole from PSGallery' {
-            Install-PowerShellModule
+            Install-PwshSpectreDependency
             Should -Invoke Install-Module -Times 1 -ParameterFilter {
                 $Name -eq 'PwshSpectreConsole' -and
                 $Repository -eq 'PSGallery' -and
@@ -247,10 +249,11 @@ Describe 'Install-PowerShellModule' {
             Mock Get-PackageProvider { $null } -ParameterFilter { $Name -eq 'NuGet' }
             Mock Install-PackageProvider {}
             Mock Install-Module {}
+            Mock Write-Host {}
         }
 
         It 'installs NuGet provider before the module' {
-            Install-PowerShellModule
+            Install-PwshSpectreDependency
             Should -Invoke Install-PackageProvider -Times 1 -ParameterFilter {
                 $Name -eq 'NuGet' -and
                 $Scope -eq 'CurrentUser'

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -285,13 +285,14 @@ if (-not $InPlace) {
         }
     }
 
-    function Install-PowerShellModule {
+    function Install-PwshSpectreDependency {
         <#
         .SYNOPSIS
-            Installs required PowerShell modules from PSGallery. Idempotent.
+            Installs PwshSpectreConsole for TUI-based shortcut tools.
         .DESCRIPTION
-            Installs PwshSpectreConsole v2 for the WSL Manager TUI.
-            Ensures NuGet provider is available before installing modules.
+            Several shortcut tools use PwshSpectreConsole for their terminal UI.
+            Cannot delegate to individual tools because install.ps1 must run
+            under PS 5.1 while tool scripts require PS 7.4.
         #>
 
         # Ensure NuGet provider is available
@@ -300,7 +301,7 @@ if (-not $InPlace) {
             Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser
         }
 
-        # PwshSpectreConsole v2 (TUI primitives for WSL Manager)
+        # PwshSpectreConsole v2 (TUI primitives for shortcut tools)
         if (Get-InstalledModule -Name PwshSpectreConsole -MinimumVersion 2.0 -ErrorAction SilentlyContinue) {
             Write-Status "PwshSpectreConsole is already installed"
         }
@@ -331,7 +332,7 @@ if (-not $InPlace) {
             Install-ScoopDependency
             Install-Git
             Install-MandatoryToolset
-            Install-PowerShellModule
+            Install-PwshSpectreDependency
             Install-OptionalToolset
 
             # Post-install: Keypirinha config

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -285,6 +285,32 @@ if (-not $InPlace) {
         }
     }
 
+    function Install-PowerShellModule {
+        <#
+        .SYNOPSIS
+            Installs required PowerShell modules from PSGallery. Idempotent.
+        .DESCRIPTION
+            Installs PwshSpectreConsole v2 for the WSL Manager TUI.
+            Ensures NuGet provider is available before installing modules.
+        #>
+
+        # Ensure NuGet provider is available
+        if (-not (Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction SilentlyContinue)) {
+            Write-Status "Installing NuGet package provider..."
+            Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser
+        }
+
+        # PwshSpectreConsole v2 (TUI primitives for WSL Manager)
+        if (Get-InstalledModule -Name PwshSpectreConsole -MinimumVersion 2.0 -ErrorAction SilentlyContinue) {
+            Write-Status "PwshSpectreConsole is already installed"
+        }
+        else {
+            Write-Status "Installing PwshSpectreConsole..."
+            Install-Module -Name PwshSpectreConsole -Repository PSGallery -Scope CurrentUser -Force -MinimumVersion 2.0 -SkipPublisherCheck
+            Write-Success "PwshSpectreConsole installed"
+        }
+    }
+
     #endregion
 
     #region Main Execution (guarded - not triggered by dot-sourcing)
@@ -305,6 +331,7 @@ if (-not $InPlace) {
             Install-ScoopDependency
             Install-Git
             Install-MandatoryToolset
+            Install-PowerShellModule
             Install-OptionalToolset
 
             # Post-install: Keypirinha config

--- a/docs/architecture/wsl-manager-c4.md
+++ b/docs/architecture/wsl-manager-c4.md
@@ -1,0 +1,183 @@
+[← Back to Docs](../wsl-manager.md)
+
+# WSL Manager — C4 Architecture (SC-016)
+
+This document describes the planned architecture for the WSL Manager with the modernized PwshSpectreConsole TUI, following the [C4 model](https://c4model.com/) at three levels: Context, Container, and Component.
+
+All diagrams use [Mermaid.js](https://mermaid.js.org/) C4 syntax.
+
+---
+
+## Level 1 — System Context
+
+Shows the WSL Manager system in relation to its users and the external systems it interacts with.
+
+```mermaid
+C4Context
+    title WSL Manager — System Context Diagram
+
+    Person(user, "Developer / DevOps Engineer", "Manages WSL distributions for local development environments")
+
+    System(wslManager, "WSL Manager", "PowerShell-based interactive tool for managing WSL distributions: install, clone, remove, update, configure Docker/Podman/DevPod, proxy, and user setup")
+
+    System_Ext(wsl2, "Windows Subsystem for Linux 2", "Microsoft's Linux compatibility layer; manages distribution lifecycle via wsl.exe")
+    System_Ext(psGallery, "PowerShell Gallery", "Module repository; source for PwshSpectreConsole dependency")
+    System_Ext(dockerRepo, "Docker / Podman Repositories", "APT package repositories for container engine installation inside WSL distributions")
+    System_Ext(devpodCdn, "DevPod CDN", "Download endpoint for the DevPod CLI binary")
+    System_Ext(corpProxy, "Corporate Proxy / PAC", "Optional corporate proxy infrastructure; auto-detected from Windows registry")
+
+    Rel(user, wslManager, "Interacts via TUI or CLI", "Terminal / pwsh")
+    Rel(wslManager, wsl2, "Invokes wsl.exe for distribution lifecycle", "CLI / process")
+    Rel(wslManager, psGallery, "Installs PwshSpectreConsole module", "Install-Module")
+    Rel(wslManager, dockerRepo, "Installs Docker/Podman inside WSL distros", "bash scripts via wsl.exe")
+    Rel(wslManager, devpodCdn, "Downloads DevPod CLI into WSL distros", "curl via wsl.exe")
+    Rel(wslManager, corpProxy, "Reads proxy settings from registry/PAC", "Windows registry")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+---
+
+## Level 2 — Container Diagram
+
+Zooms into the WSL Manager system, showing its internal containers (executable units / deployable modules) and how they collaborate.
+
+```mermaid
+C4Container
+    title WSL Manager — Container Diagram
+
+    Person(user, "Developer", "Manages WSL distributions")
+
+    System_Boundary(wslManagerSystem, "WSL Manager System") {
+        Container(entryPoint, "wsl-manager.ps1", "PowerShell Script", "CLI entry point; parses parameters and delegates to the manager orchestrator")
+        Container(tuiLayer, "TUI Layer (manager.ps1)", "PowerShell + PwshSpectreConsole", "Interactive menu with arrow-key navigation, rich tables, and confirmation dialogs; planned SC-016 modernization")
+        Container(dispatcher, "Command Dispatcher (commands.ps1)", "PowerShell Script", "Routes commands to action functions; contains all Invoke-* workflow handlers and distro selection logic")
+        Container(wslLib, "WSL Library (lib/wsl/)", "PowerShell Modules", "Core WSL operations: distro lifecycle, exec, user, wsl.conf, Docker, Podman, DevPod, proxy")
+        Container(bashScripts, "Bash Install Scripts", "Shell Scripts", "Executed inside WSL distros for Docker, Podman, DevPod installation, and proxy configuration")
+        Container(utilsLib, "Utilities (lib/utils/)", "PowerShell Module", "Shared helpers: Invoke-CommandLine, console output, path management, CI detection")
+    }
+
+    System_Ext(wsl2, "WSL 2 (wsl.exe)", "Distribution lifecycle management")
+    System_Ext(spectreConsole, "PwshSpectreConsole", "Terminal UI primitives: selection prompts, tables, confirmations")
+    System_Ext(proxyInfra, "Corporate Proxy / PAC", "Proxy auto-detection via Windows registry")
+
+    Rel(user, entryPoint, "Runs with command args", "pwsh CLI")
+    Rel(user, tuiLayer, "Interacts via keyboard", "Terminal")
+    Rel(entryPoint, tuiLayer, "Delegates interactive mode", "dot-source")
+    Rel(entryPoint, dispatcher, "Delegates CLI commands", "function call")
+    Rel(tuiLayer, dispatcher, "Routes menu selection to command", "Invoke-WslCommand")
+    Rel(tuiLayer, spectreConsole, "Renders menus, tables, confirmations", "Read-SpectreSelection, Format-SpectreTable")
+    Rel(dispatcher, wslLib, "Calls WSL operations", "function calls")
+    Rel(wslLib, wsl2, "Manages distributions", "wsl.exe CLI")
+    Rel(wslLib, bashScripts, "Executes inside distros", "wsl.exe --exec bash")
+    Rel(wslLib, utilsLib, "Uses shared helpers", "dot-source")
+    Rel(wslLib, proxyInfra, "Reads proxy settings", "registry / setProxy.ps1")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+---
+
+## Level 3 — Component Diagram
+
+Zooms into the WSL Library container, showing the individual PowerShell modules and their responsibilities.
+
+```mermaid
+C4Component
+    title WSL Manager — Component Diagram (WSL Library)
+
+    Container_Boundary(tuiContainer, "TUI Layer") {
+        Component(showMenu, "Show-WslMenu", "Planned SC-016", "Arrow-key menu using Read-SpectreSelection; replaces Read-Host letter input")
+        Component(showTable, "Show-WslDistroTable", "Planned SC-016", "Rich distro table using Format-SpectreTable with colored status columns")
+        Component(selectDistro, "Select-WslDistro", "Planned SC-016", "Distro picker using Read-SpectreSelection; replaces numbered Read-Host input")
+        Component(confirmAction, "Confirm-DestructiveAction", "Planned SC-016", "Read-SpectreConfirm for remove, terminate, shutdown operations")
+    }
+
+    Container_Boundary(dispatcherContainer, "Command Dispatcher (commands.ps1)") {
+        Component(invokeWslCmd, "Invoke-WslCommand", "PowerShell", "Central dispatch: routes command string to the matching Invoke-* handler")
+        Component(invokeCreate, "Invoke-CreateDistro", "PowerShell", "Install workflow: lists available distros, prompts for selection, calls New-WslDistro")
+        Component(invokeClone, "Invoke-CloneDistro", "PowerShell", "Clone workflow: select source distro, prompt target name, calls Copy-WslDistro")
+        Component(invokeRemove, "Invoke-RemoveDistro", "PowerShell", "Remove workflow: select distro, calls Remove-WslDistro")
+        Component(invokeSetup, "Invoke-Setup* Handlers", "PowerShell", "Setup workflows: User, Docker, Podman, DevPod, Proxy — each delegates to lib functions")
+        Component(invokeOps, "Invoke-TerminateDistro / Invoke-ShutdownWsl", "PowerShell", "Operational commands: stop single distro or shutdown entire WSL subsystem")
+    }
+
+    Container_Boundary(wslLibContainer, "WSL Library (lib/wsl/)") {
+        Component(core, "core.ps1", "PowerShell", "WSL status checks: Test-WslInstalled, Assert-Wsl2Installed, Get-WslDistroList, Get-WslDistroState, Get-WslDistroType, Stop-WslDistro")
+        Component(install, "install.ps1", "PowerShell", "Distribution provisioning: Get-WslAvailableDistro, New-WslDistro")
+        Component(ops, "ops.ps1", "PowerShell", "Distribution operations: Remove-WslDistro, Copy-WslDistro, Update-WslDistro, Stop-WslSubsystem, Merge-WslConfig, Invoke-ConfigureWsl")
+        Component(exec, "exec.ps1", "PowerShell", "Command execution bridge: Invoke-WslDistroCommand, Invoke-WslDistroScript — runs bash inside WSL distros")
+        Component(wslConf, "wsl-conf.ps1", "PowerShell", "Per-distro configuration: Set-WslConf, Test-WslSystemdConfigured, Test-WslInteropConfigured, Test-WslAutomountConfigured")
+        Component(userMgmt, "user.ps1", "PowerShell", "User management: New-WslUser, Get-WslDefaultUser")
+        Component(docker, "docker.ps1", "PowerShell", "Docker Engine lifecycle: Test-WslDockerInstalled, Install-WslDockerEngine")
+        Component(podman, "podman.ps1", "PowerShell", "Rootless Podman lifecycle: Test-WslPodmanInstalled, Install-WslPodman")
+        Component(devpod, "devpod.ps1", "PowerShell", "DevPod CLI lifecycle: Test-WslDevPodInstalled, Install-WslDevPod")
+        Component(proxy, "proxy.ps1", "PowerShell", "Proxy configuration: Install-WslProxy — auto-detects PAC/registry, configures .profile, apt, Docker, Podman")
+    }
+
+    Container_Boundary(scriptContainer, "Bash Install Scripts (lib/wsl/scripts/)") {
+        Component(dockerSh, "install-docker.sh", "Bash", "Installs Docker CE, Docker Compose; configures binfmt.d; adds user to docker group")
+        Component(podmanSh, "install-podman.sh", "Bash", "Installs Podman rootless; configures subuid/subgid and registries")
+        Component(devpodSh, "install-devpod.sh", "Bash", "Downloads DevPod CLI binary; configures container provider (docker/podman)")
+        Component(proxySh, "setup-proxy.sh", "Bash", "Writes proxy env vars to .profile, apt.conf, Docker config, Podman config")
+    }
+
+    Rel(showMenu, invokeWslCmd, "Selected command")
+    Rel(showTable, core, "Get-WslDistroList -Detailed")
+    Rel(selectDistro, core, "Get-WslDistroList -Detailed")
+    Rel(confirmAction, invokeOps, "Confirmed destructive action")
+
+    Rel(invokeWslCmd, invokeCreate, "install")
+    Rel(invokeWslCmd, invokeClone, "clone")
+    Rel(invokeWslCmd, invokeRemove, "remove")
+    Rel(invokeWslCmd, invokeSetup, "setup-*")
+    Rel(invokeWslCmd, invokeOps, "terminate / shutdown")
+
+    Rel(invokeCreate, install, "New-WslDistro")
+    Rel(invokeClone, ops, "Copy-WslDistro")
+    Rel(invokeRemove, ops, "Remove-WslDistro")
+    Rel(invokeSetup, docker, "Install-WslDockerEngine")
+    Rel(invokeSetup, podman, "Install-WslPodman")
+    Rel(invokeSetup, devpod, "Install-WslDevPod")
+    Rel(invokeSetup, proxy, "Install-WslProxy")
+    Rel(invokeSetup, userMgmt, "New-WslUser")
+    Rel(invokeOps, core, "Stop-WslDistro")
+    Rel(invokeOps, ops, "Stop-WslSubsystem")
+
+    Rel(docker, exec, "Invoke-WslDistroScript")
+    Rel(docker, wslConf, "Set-WslConf, Test-*Configured")
+    Rel(podman, exec, "Invoke-WslDistroScript")
+    Rel(podman, wslConf, "Set-WslConf, Test-*Configured")
+    Rel(devpod, exec, "Invoke-WslDistroScript")
+    Rel(proxy, exec, "Invoke-WslDistroScript")
+    Rel(userMgmt, exec, "Invoke-WslDistroCommand")
+    Rel(userMgmt, wslConf, "Set-WslConf")
+
+    Rel(exec, dockerSh, "install-docker.sh")
+    Rel(exec, podmanSh, "install-podman.sh")
+    Rel(exec, devpodSh, "install-devpod.sh")
+    Rel(exec, proxySh, "setup-proxy.sh")
+
+    UpdateLayoutConfig($c4ShapeInRow="4", $c4BoundaryInRow="1")
+```
+
+---
+
+## SC-016 Change Impact Summary
+
+The following table maps the planned SC-016 changes to the affected components:
+
+| SC-016 Change | Current Implementation | Planned Implementation | Affected Components |
+|---|---|---|---|
+| Menu selection | `Read-Host` letter input | `Read-SpectreSelection` arrow-key navigation | `manager.ps1` → `Show-WslMenu` (new) |
+| Distro table | `Write-Host` with basic colors | `Format-SpectreTable` with borders and colored status | `commands.ps1` → `Show-WslDistroTable` (new) |
+| Distro picker | `Read-Host` numbered input | `Read-SpectreSelection` for distro lists | `commands.ps1` → `Select-WslDistro` (modified) |
+| Destructive confirmations | Implicit (no confirmation in TUI) | `Read-SpectreConfirm` for remove, terminate, shutdown | `commands.ps1` → `Confirm-DestructiveAction` (new) |
+| Status coloring | `Write-Host -ForegroundColor` | Spectre markup: `[green]Running[/]`, `[red]Stopped[/]` | `Show-WslDistroTable` |
+| Module dependency | None | `PwshSpectreConsole` v2 from PSGallery | Setup process / `Install-Module` |
+
+### Key architectural principle
+
+> Only the **TUI layer** changes. The `commands.ps1` action functions (`Invoke-*`) and the entire `lib/wsl/` library remain structurally unchanged.
+
+[← Back to Docs](../wsl-manager.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -13,9 +13,9 @@
 ### In Progress
 - [SC-001 — Backlog refinement](sc-001.md)
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
+  - [SC-016b — Replace main menu with Read-SpectreSelection](sc-016b.md)
 
 ### Open
-  - [SC-016b — Replace main menu with Read-SpectreSelection](sc-016b.md)
   - [SC-016c — Replace distro table with Format-SpectreTable](sc-016c.md)
   - [SC-016d — Replace distro selection with Read-SpectreSelection](sc-016d.md)
   - [SC-016e — Add Read-SpectreConfirm for destructive operations](sc-016e.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -15,6 +15,11 @@
 
 ### Open
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
+  - [SC-016a — Add PwshSpectreConsole module dependency to setup process](sc-016a.md)
+  - [SC-016b — Replace main menu with Read-SpectreSelection](sc-016b.md)
+  - [SC-016c — Replace distro table with Format-SpectreTable](sc-016c.md)
+  - [SC-016d — Replace distro selection with Read-SpectreSelection](sc-016d.md)
+  - [SC-016e — Add Read-SpectreConfirm for destructive operations](sc-016e.md)
 - [SC-028 — Improve WSL manager console output handling](sc-028.md)
 - [SC-030 — Add progress indicators and status feedback with PwshSpectreConsole](sc-030.md)
 - [SC-031 — Redesign menu layout with grouped commands and contextual help](sc-031.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -12,10 +12,10 @@
 
 ### In Progress
 - [SC-001 — Backlog refinement](sc-001.md)
-
-### Open
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
   - [SC-016a — Add PwshSpectreConsole module dependency to setup process](sc-016a.md)
+
+### Open
   - [SC-016b — Replace main menu with Read-SpectreSelection](sc-016b.md)
   - [SC-016c — Replace distro table with Format-SpectreTable](sc-016c.md)
   - [SC-016d — Replace distro selection with Read-SpectreSelection](sc-016d.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -25,6 +25,7 @@
 - [SC-017 — Auto-terminate distros instead of prompting the user](sc-017.md)
 - [SC-020 — Import and export WSL distributions to/from files](sc-020.md)
 - [SC-023 — Per-file code coverage in testrunner.ps1](sc-023.md)
+- [SC-032 — Investigate split-pane TUI layout for WSL Manager](sc-032.md)
 
 ### Done
 - [SC-016a — Add PwshSpectreConsole module dependency to setup process](sc-016a.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -25,8 +25,10 @@
 - [SC-020 — Import and export WSL distributions to/from files](sc-020.md)
 - [SC-023 — Per-file code coverage in testrunner.ps1](sc-023.md)
 - [SC-032 — Investigate split-pane TUI layout for WSL Manager](sc-032.md)
+- [SC-034 — Shared dependency utilities and auto-discovery](sc-034.md)
 
 ### Done
+- [SC-033 — Tool-level dependency declaration and installation](sc-033.md)
 - [SC-016b — Replace main menu with Read-SpectreSelection](sc-016b.md)
 - [SC-016a — Add PwshSpectreConsole module dependency to setup process](sc-016a.md)
 - [SC-029 — Drop PowerShell 5.1 requirement and adopt PowerShell 7.6+](sc-029.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -13,7 +13,6 @@
 ### In Progress
 - [SC-001 — Backlog refinement](sc-001.md)
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
-  - [SC-016a — Add PwshSpectreConsole module dependency to setup process](sc-016a.md)
 
 ### Open
   - [SC-016b — Replace main menu with Read-SpectreSelection](sc-016b.md)
@@ -28,6 +27,7 @@
 - [SC-023 — Per-file code coverage in testrunner.ps1](sc-023.md)
 
 ### Done
+- [SC-016a — Add PwshSpectreConsole module dependency to setup process](sc-016a.md)
 - [SC-029 — Drop PowerShell 5.1 requirement and adopt PowerShell 7.6+](sc-029.md)
 - [SC-027 — Make shared skills available to Claude GitHub App via plugin](sc-027.md)
 - [SC-013 — Fix and enhance documentation](sc-013.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -13,7 +13,6 @@
 ### In Progress
 - [SC-001 — Backlog refinement](sc-001.md)
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
-  - [SC-016b — Replace main menu with Read-SpectreSelection](sc-016b.md)
 
 ### Open
   - [SC-016c — Replace distro table with Format-SpectreTable](sc-016c.md)
@@ -28,6 +27,7 @@
 - [SC-032 — Investigate split-pane TUI layout for WSL Manager](sc-032.md)
 
 ### Done
+- [SC-016b — Replace main menu with Read-SpectreSelection](sc-016b.md)
 - [SC-016a — Add PwshSpectreConsole module dependency to setup process](sc-016a.md)
 - [SC-029 — Drop PowerShell 5.1 requirement and adopt PowerShell 7.6+](sc-029.md)
 - [SC-027 — Make shared skills available to Claude GitHub App via plugin](sc-027.md)

--- a/docs/backlog/sc-016.md
+++ b/docs/backlog/sc-016.md
@@ -56,7 +56,7 @@ This story is broken into five independently UAT-able subtasks:
 SC-016a is the foundation; SC-016b/c/d can proceed in any order after it. SC-016e depends on SC-016d (needs the Spectre-based distro picker).
 
 **Acceptance Criteria**:
-- [ ] PwshSpectreConsole module is installed as part of the setup process
+- [x] PwshSpectreConsole module is installed as part of the setup process
 - [ ] Main menu uses `Read-SpectreSelection` with arrow-key navigation
 - [ ] Menu options respond immediately to selection (no Enter + letter required)
 - [ ] Pressing Esc at any interactive step returns to the main menu

--- a/docs/backlog/sc-016.md
+++ b/docs/backlog/sc-016.md
@@ -57,8 +57,8 @@ SC-016a is the foundation; SC-016b/c/d can proceed in any order after it. SC-016
 
 **Acceptance Criteria**:
 - [x] PwshSpectreConsole module is installed as part of the setup process
-- [ ] Main menu uses `Read-SpectreSelection` with arrow-key navigation
-- [ ] Menu options respond immediately to selection (no Enter + letter required)
+- [x] Main menu uses `Read-SpectreSelection` with arrow-key navigation
+- [x] Menu options respond immediately to selection (no Enter + letter required)
 - [ ] Pressing Esc at any interactive step returns to the main menu
 - [ ] Distro table rendered with `Format-SpectreTable` (borders, colored status)
 - [ ] Distro selection uses `Read-SpectreSelection` instead of `Read-Host`

--- a/docs/backlog/sc-016.md
+++ b/docs/backlog/sc-016.md
@@ -59,7 +59,7 @@ SC-016a is the foundation; SC-016b/c/d can proceed in any order after it. SC-016
 - [x] PwshSpectreConsole module is installed as part of the setup process
 - [x] Main menu uses `Read-SpectreSelection` with arrow-key navigation
 - [x] Menu options respond immediately to selection (no Enter + letter required)
-- [ ] Pressing Esc at any interactive step returns to the main menu
+- [ ] Pressing Ctrl+C at any interactive step returns to the main menu
 - [ ] Distro table rendered with `Format-SpectreTable` (borders, colored status)
 - [ ] Distro selection uses `Read-SpectreSelection` instead of `Read-Host`
 - [ ] Destructive operations (remove, terminate, shutdown) use `Read-SpectreConfirm`

--- a/docs/backlog/sc-016.md
+++ b/docs/backlog/sc-016.md
@@ -43,6 +43,18 @@ PwshSpectreConsole was selected over alternatives for these reasons:
 - Existing `commands.ps1` action functions remain unchanged - only the TUI layer changes
 - Original key-letter shortcuts preserved as accelerators alongside arrow-key navigation
 
+### Subtasks
+
+This story is broken into five independently UAT-able subtasks:
+
+1. [SC-016a](sc-016a.md) - Add PwshSpectreConsole module dependency to setup process
+2. [SC-016b](sc-016b.md) - Replace main menu with `Read-SpectreSelection`
+3. [SC-016c](sc-016c.md) - Replace distro table with `Format-SpectreTable`
+4. [SC-016d](sc-016d.md) - Replace distro selection with `Read-SpectreSelection`
+5. [SC-016e](sc-016e.md) - Add `Read-SpectreConfirm` for destructive operations
+
+SC-016a is the foundation; SC-016b/c/d can proceed in any order after it. SC-016e depends on SC-016d (needs the Spectre-based distro picker).
+
 **Acceptance Criteria**:
 - [ ] PwshSpectreConsole module is installed as part of the setup process
 - [ ] Main menu uses `Read-SpectreSelection` with arrow-key navigation

--- a/docs/backlog/sc-016.md
+++ b/docs/backlog/sc-016.md
@@ -2,7 +2,7 @@
 
 # [SC-016] Modernize WSL Manager TUI with PwshSpectreConsole
 
-**Status**: Open
+**Status**: In Progress
 **Priority**: High
 **Component**: `lib/wsl/manager.ps1`, `lib/wsl/commands.ps1`, `tools/wsl-manager/wsl-manager.ps1`
 **Depends on**: [SC-029](sc-029.md)

--- a/docs/backlog/sc-016a.md
+++ b/docs/backlog/sc-016a.md
@@ -2,7 +2,7 @@
 
 # [SC-016a] Add PwshSpectreConsole module dependency to setup process
 
-**Status**: Open
+**Status**: In Progress
 **Priority**: High
 **Component**: `bin/install.ps1`, `lib/wsl/manager.ps1`
 **Parent**: [SC-016](sc-016.md)

--- a/docs/backlog/sc-016a.md
+++ b/docs/backlog/sc-016a.md
@@ -1,0 +1,34 @@
+[<- Back to Backlog](README.md)
+
+# [SC-016a] Add PwshSpectreConsole module dependency to setup process
+
+**Status**: Open
+**Priority**: High
+**Component**: `bin/install.ps1`, `lib/wsl/manager.ps1`
+**Parent**: [SC-016](sc-016.md)
+**Depends on**: [SC-029](sc-029.md)
+
+**Summary**:
+As a developer, I want PwshSpectreConsole v2 installed automatically as part of the project setup so that subsequent TUI modernization tasks can use its cmdlets.
+
+**Description**:
+Add `PwshSpectreConsole` module installation to the local-mode setup process in `bin/install.ps1`, after `Install-MandatoryToolset` ensures `pwsh` is available. Add an import guard in `manager.ps1` so the TUI layer loads the module at startup and fails gracefully if missing.
+
+The test initialization script (`test/bin/init.ps1`) already demonstrates the pattern for installing PSGallery modules (Pester, PSScriptAnalyzer) - follow the same approach.
+
+### Technical approach
+
+- Add a new function (or extend existing setup) in `bin/install.ps1` to install `PwshSpectreConsole` v2 via `Install-Module -Name PwshSpectreConsole -Repository PSGallery -Scope CurrentUser`
+- Add `Import-Module PwshSpectreConsole -ErrorAction Stop` to `manager.ps1`
+- Unit test: mock `Install-Module`, verify it is called with correct parameters
+- No functional TUI changes yet - existing menu continues to work
+
+**Acceptance Criteria**:
+- [ ] `bin/install.ps1` installs `PwshSpectreConsole` v2 in local mode
+- [ ] `manager.ps1` imports `PwshSpectreConsole` at startup
+- [ ] Module import failure produces a clear error message
+- [ ] New install function has Pester unit tests
+- [ ] All existing tests continue to pass
+- [ ] `Get-Module -ListAvailable PwshSpectreConsole` returns v2 after setup
+
+[<- Back to Backlog](README.md)

--- a/docs/backlog/sc-016a.md
+++ b/docs/backlog/sc-016a.md
@@ -1,8 +1,8 @@
 [<- Back to Backlog](README.md)
 
-# [SC-016a] Add PwshSpectreConsole module dependency to setup process
+# [SC-016a] ✅ DONE - Add PwshSpectreConsole module dependency to setup process
 
-**Status**: In Progress
+**Status**: Done (2026-04-03)
 **Priority**: High
 **Component**: `bin/install.ps1`, `lib/wsl/manager.ps1`
 **Parent**: [SC-016](sc-016.md)
@@ -24,11 +24,11 @@ The test initialization script (`test/bin/init.ps1`) already demonstrates the pa
 - No functional TUI changes yet - existing menu continues to work
 
 **Acceptance Criteria**:
-- [ ] `bin/install.ps1` installs `PwshSpectreConsole` v2 in local mode
-- [ ] `manager.ps1` imports `PwshSpectreConsole` at startup
-- [ ] Module import failure produces a clear error message
-- [ ] New install function has Pester unit tests
-- [ ] All existing tests continue to pass
-- [ ] `Get-Module -ListAvailable PwshSpectreConsole` returns v2 after setup
+- [x] `bin/install.ps1` installs `PwshSpectreConsole` v2 in local mode
+- [x] `manager.ps1` imports `PwshSpectreConsole` at startup
+- [x] Module import failure produces a clear error message
+- [x] New install function has Pester unit tests
+- [x] All existing tests continue to pass
+- [x] `Get-Module -ListAvailable PwshSpectreConsole` returns v2 after setup
 
 [<- Back to Backlog](README.md)

--- a/docs/backlog/sc-016b.md
+++ b/docs/backlog/sc-016b.md
@@ -1,8 +1,8 @@
 [<- Back to Backlog](README.md)
 
-# [SC-016b] Replace main menu with Read-SpectreSelection
+# [SC-016b] ✅ DONE - Replace main menu with Read-SpectreSelection
 
-**Status**: In Progress
+**Status**: Done (2026-04-03)
 **Priority**: High
 **Component**: `lib/wsl/manager.ps1`, `lib/wsl/manager.Tests.ps1`
 **Parent**: [SC-016](sc-016.md)
@@ -25,10 +25,10 @@ Replace the current `Write-Host` menu + `Read-Host` letter input in `Start-Inter
 - Update `manager.Tests.ps1`: mock `Read-SpectreSelection` instead of `Read-Host`, test Esc returns `$null` and exits loop, test valid selection dispatches correct command
 
 **Acceptance Criteria**:
-- [ ] Main menu uses `Read-SpectreSelection` with arrow-key navigation
-- [ ] Menu options respond immediately on selection (no Enter + letter required)
-- [ ] Pressing Esc exits the interactive mode
-- [ ] `Show-WslMenu` function has Pester unit tests with mocked `Read-SpectreSelection`
-- [ ] All existing tests continue to pass (updated mocks)
+- [x] Main menu uses `Read-SpectreSelection` with arrow-key navigation
+- [x] Menu options respond immediately on selection (no Enter + letter required)
+- [x] Ctrl+C or selecting "Quit" exits the interactive mode
+- [x] `Show-WslMenu` function has Pester unit tests with mocked `Read-SpectreSelection`
+- [x] All existing tests continue to pass (updated mocks)
 
 [<- Back to Backlog](README.md)

--- a/docs/backlog/sc-016b.md
+++ b/docs/backlog/sc-016b.md
@@ -2,7 +2,7 @@
 
 # [SC-016b] Replace main menu with Read-SpectreSelection
 
-**Status**: Open
+**Status**: In Progress
 **Priority**: High
 **Component**: `lib/wsl/manager.ps1`, `lib/wsl/manager.Tests.ps1`
 **Parent**: [SC-016](sc-016.md)

--- a/docs/backlog/sc-016b.md
+++ b/docs/backlog/sc-016b.md
@@ -1,0 +1,34 @@
+[<- Back to Backlog](README.md)
+
+# [SC-016b] Replace main menu with Read-SpectreSelection
+
+**Status**: Open
+**Priority**: High
+**Component**: `lib/wsl/manager.ps1`, `lib/wsl/manager.Tests.ps1`
+**Parent**: [SC-016](sc-016.md)
+**Depends on**: [SC-016a](sc-016a.md)
+
+**Summary**:
+As a user, I want the main menu to use arrow-key navigation with instant selection so that I no longer need to type a letter and press Enter.
+
+**Description**:
+Replace the current `Write-Host` menu + `Read-Host` letter input in `Start-InteractiveMode` with a `Read-SpectreSelection` prompt. Pressing Esc exits the menu loop.
+
+### Technical approach
+
+- Extract a new `Show-WslMenu` function that calls `Read-SpectreSelection` with menu option labels as choices
+- Returns the selected command string (e.g., "install", "remove") or `$null` on Esc/cancel
+- Refactor `Start-InteractiveMode` to call `Show-WslMenu` instead of the `Write-Host` block + `Read-Host`
+- Remove the `$menuKeyMap` hashtable (letter-key mapping no longer needed)
+- Remove `Clear-Host` per-loop call (Spectre handles terminal rendering)
+- Remove `Read-Host "Press Enter to continue"` pause after command execution
+- Update `manager.Tests.ps1`: mock `Read-SpectreSelection` instead of `Read-Host`, test Esc returns `$null` and exits loop, test valid selection dispatches correct command
+
+**Acceptance Criteria**:
+- [ ] Main menu uses `Read-SpectreSelection` with arrow-key navigation
+- [ ] Menu options respond immediately on selection (no Enter + letter required)
+- [ ] Pressing Esc exits the interactive mode
+- [ ] `Show-WslMenu` function has Pester unit tests with mocked `Read-SpectreSelection`
+- [ ] All existing tests continue to pass (updated mocks)
+
+[<- Back to Backlog](README.md)

--- a/docs/backlog/sc-016c.md
+++ b/docs/backlog/sc-016c.md
@@ -1,6 +1,6 @@
 [<- Back to Backlog](README.md)
 
-# [SC-016c] Replace distro table with Format-SpectreTable
+# [SC-016c] Replace distro table with Format-SpectreTable and add split-panel layout
 
 **Status**: Open
 **Priority**: High
@@ -9,10 +9,25 @@
 **Depends on**: [SC-016a](sc-016a.md)
 
 **Summary**:
-As a user, I want the distribution list displayed as a rich bordered table with color-coded status so that I can quickly see the state of my WSL distributions.
+As a user, I want the distribution list displayed as a rich bordered table with color-coded status, alongside a command output panel, so that I can see both distribution state and recent command results above the menu prompt.
 
 **Description**:
 Replace `Show-WslDistroList` + `Format-DistroListEntry` with a new `Show-WslDistroTable` function using `Format-SpectreTable`. Status values use Spectre markup for coloring: `[green]Running[/]`, `[grey]Stopped[/]`.
+
+Add a two-column layout above the `Read-SpectreSelection` menu prompt using `New-SpectreLayout -Columns`: the left panel shows the distro table, the right panel shows the last command's console output. Both panels use `Format-SpectrePanel` with borders and take roughly half the terminal width.
+
+```
++-- Distributions ---------------+ +-- Output ----------------------+
+|  # Name        State    Ver    | | V Terminated 'ubu-dev'         |
+|  1 Ubuntu      Running  WSL2   | |                                |
+|  2 ubu-dev     Stopped  WSL2   | |                                |
++--------------------------------+ +--------------------------------+
+
+WSL Manager
+> Install new distribution
+  Clone distribution
+  ...
+```
 
 ### Technical approach
 
@@ -20,15 +35,21 @@ Replace `Show-WslDistroList` + `Format-DistroListEntry` with a new `Show-WslDist
 - Columns: #, Name, State (color-coded), Version (WSL1/WSL2), Default
 - Keep the same `-Distros` parameter signature as `Show-WslDistroList`
 - Remove `Format-DistroListEntry` and `Show-WslDistroList` (replaced)
-- Update `Start-InteractiveMode` in `manager.ps1` to call `Show-WslDistroTable`
+- In `manager.ps1`, build a two-column layout with `New-SpectreLayout -Columns`:
+  - Left: distro table in a `Format-SpectrePanel` with header "Distributions"
+  - Right: last command output in a `Format-SpectrePanel` with header "Output"
+- Capture command output (via `-OutVariable` or stream redirection) and display in the right panel on next loop iteration
+- Replace the single `Format-SpectrePanel` header with the two-column layout
 - Update tests in both `commands.Tests.ps1` and `manager.Tests.ps1`
-- Mock `Format-SpectreTable` in tests to verify correct table structure
+- Mock `Format-SpectreTable`, `New-SpectreLayout`, `Format-SpectrePanel` in tests
 
 **Acceptance Criteria**:
 - [ ] Distro table rendered with `Format-SpectreTable` (borders, alignment)
 - [ ] Running distros show `[green]Running[/]`, stopped show `[grey]Stopped[/]`
 - [ ] Default distro is visually marked in the table
 - [ ] "No WSL distributions found" message still shown when empty
+- [ ] Two-column layout: distro table (left) and command output (right) above the menu
+- [ ] Command output panel shows the result of the last executed command
 - [ ] `Show-WslDistroTable` has Pester unit tests with mocked Spectre cmdlets
 - [ ] All existing tests continue to pass (updated references)
 

--- a/docs/backlog/sc-016c.md
+++ b/docs/backlog/sc-016c.md
@@ -1,0 +1,35 @@
+[<- Back to Backlog](README.md)
+
+# [SC-016c] Replace distro table with Format-SpectreTable
+
+**Status**: Open
+**Priority**: High
+**Component**: `lib/wsl/commands.ps1`, `lib/wsl/commands.Tests.ps1`, `lib/wsl/manager.ps1`, `lib/wsl/manager.Tests.ps1`
+**Parent**: [SC-016](sc-016.md)
+**Depends on**: [SC-016a](sc-016a.md)
+
+**Summary**:
+As a user, I want the distribution list displayed as a rich bordered table with color-coded status so that I can quickly see the state of my WSL distributions.
+
+**Description**:
+Replace `Show-WslDistroList` + `Format-DistroListEntry` with a new `Show-WslDistroTable` function using `Format-SpectreTable`. Status values use Spectre markup for coloring: `[green]Running[/]`, `[grey]Stopped[/]`.
+
+### Technical approach
+
+- Create `Show-WslDistroTable` in `commands.ps1` using `Format-SpectreTable`
+- Columns: #, Name, State (color-coded), Version (WSL1/WSL2), Default
+- Keep the same `-Distros` parameter signature as `Show-WslDistroList`
+- Remove `Format-DistroListEntry` and `Show-WslDistroList` (replaced)
+- Update `Start-InteractiveMode` in `manager.ps1` to call `Show-WslDistroTable`
+- Update tests in both `commands.Tests.ps1` and `manager.Tests.ps1`
+- Mock `Format-SpectreTable` in tests to verify correct table structure
+
+**Acceptance Criteria**:
+- [ ] Distro table rendered with `Format-SpectreTable` (borders, alignment)
+- [ ] Running distros show `[green]Running[/]`, stopped show `[grey]Stopped[/]`
+- [ ] Default distro is visually marked in the table
+- [ ] "No WSL distributions found" message still shown when empty
+- [ ] `Show-WslDistroTable` has Pester unit tests with mocked Spectre cmdlets
+- [ ] All existing tests continue to pass (updated references)
+
+[<- Back to Backlog](README.md)

--- a/docs/backlog/sc-016d.md
+++ b/docs/backlog/sc-016d.md
@@ -1,0 +1,33 @@
+[<- Back to Backlog](README.md)
+
+# [SC-016d] Replace distro selection with Read-SpectreSelection
+
+**Status**: Open
+**Priority**: High
+**Component**: `lib/wsl/commands.ps1`, `lib/wsl/commands.Tests.ps1`
+**Parent**: [SC-016](sc-016.md)
+**Depends on**: [SC-016a](sc-016a.md)
+
+**Summary**:
+As a user, I want to pick a distribution using arrow-key navigation so that I no longer need to type a number or name and press Enter.
+
+**Description**:
+Refactor `Select-WslDistro` and `Invoke-CreateDistro`'s inline selection to use `Read-SpectreSelection` for interactive distro picking. The CLI path (pre-provided `-Selection` or `-Name` parameter) remains unchanged for non-interactive use.
+
+### Technical approach
+
+- `Select-WslDistro`: when no `-Selection` is pre-provided and not in CI, use `Read-SpectreSelection` with distro names as choices. Return `$null` on Esc/cancel.
+- Keep the `-Selection` parameter path unchanged for CLI and scripted use (number or name resolution)
+- `Invoke-CreateDistro`: replace the `Read-Host` numbered selection (lines 167-203) with `Read-SpectreSelection` using `$availableDistros` as choices
+- Update `commands.Tests.ps1`: mock `Read-SpectreSelection` for interactive paths, keep CLI path tests unchanged
+- Test: cancel/Esc returns `$null`, valid selection returns distro name
+
+**Acceptance Criteria**:
+- [ ] `Select-WslDistro` uses `Read-SpectreSelection` for interactive distro picking
+- [ ] `Invoke-CreateDistro` uses `Read-SpectreSelection` for available distro selection
+- [ ] Pressing Esc at distro selection returns to main menu (returns `$null`)
+- [ ] CLI mode (`-Selection` / `-Name` provided) still works without Spectre prompts
+- [ ] Updated tests with mocked `Read-SpectreSelection`
+- [ ] All existing tests continue to pass
+
+[<- Back to Backlog](README.md)

--- a/docs/backlog/sc-016e.md
+++ b/docs/backlog/sc-016e.md
@@ -1,0 +1,34 @@
+[<- Back to Backlog](README.md)
+
+# [SC-016e] Add Read-SpectreConfirm for destructive operations
+
+**Status**: Open
+**Priority**: High
+**Component**: `lib/wsl/commands.ps1`, `lib/wsl/commands.Tests.ps1`
+**Parent**: [SC-016](sc-016.md)
+**Depends on**: [SC-016d](sc-016d.md)
+
+**Summary**:
+As a user, I want destructive operations (remove, terminate, shutdown) to ask for explicit confirmation so that I do not accidentally destroy data or stop running distributions.
+
+**Description**:
+Add a `Confirm-DestructiveAction` function wrapping `Read-SpectreConfirm` and wire it into the three destructive command functions. CLI paths (where `-Name` is provided) skip the confirmation to preserve scriptability.
+
+### Technical approach
+
+- New `Confirm-DestructiveAction` function in `commands.ps1`: takes `-Action` string (e.g., "Remove distribution 'Ubuntu'"), calls `Read-SpectreConfirm`, returns `$true`/`$false`
+- `Invoke-RemoveDistro`: after `Select-WslDistro`, call `Confirm-DestructiveAction` before `Remove-WslDistro`. Skip when `-Name` was provided directly (non-interactive CLI)
+- `Invoke-TerminateDistro`: after distro selection and running-state validation, confirm before `Stop-WslDistro`. Skip when `-Name` was provided
+- `Invoke-ShutdownWsl`: confirm before `Stop-WslSubsystem`, include running distro names in the confirmation message
+- Tests: mock `Read-SpectreConfirm`, test confirmed proceeds, test denied aborts, test CLI paths skip confirmation
+
+**Acceptance Criteria**:
+- [ ] `Confirm-DestructiveAction` function exists with Pester unit tests
+- [ ] `Invoke-RemoveDistro` prompts for confirmation in interactive mode
+- [ ] `Invoke-TerminateDistro` prompts for confirmation in interactive mode
+- [ ] `Invoke-ShutdownWsl` prompts for confirmation (shows running distro names)
+- [ ] Denying confirmation aborts the operation and returns to menu
+- [ ] CLI mode (direct `-Name` parameter) skips confirmation
+- [ ] All existing tests continue to pass
+
+[<- Back to Backlog](README.md)

--- a/docs/backlog/sc-032.md
+++ b/docs/backlog/sc-032.md
@@ -1,0 +1,29 @@
+[<- Back to Backlog](README.md)
+
+# [SC-032] Investigate split-pane TUI layout for WSL Manager
+
+**Status**: Open
+**Priority**: Low
+**Component**: `lib/wsl/manager.ps1`
+**Depends on**: [SC-016](sc-016.md)
+
+**Summary**:
+As a user, I want the WSL Manager TUI to have a split-pane layout (menu on the left, command output on the right) similar to lazygit, so that I can see command results alongside the menu.
+
+**Description**:
+PwshSpectreConsole provides `New-SpectreLayout -Columns` for side-by-side panels and `Invoke-SpectreLive` for real-time updates. However, `Read-SpectreSelection` (interactive arrow-key prompts) cannot run inside a `Invoke-SpectreLive` context: both take over terminal input/output and conflict with each other. This is a fundamental Spectre.Console limitation.
+
+### Investigation needed
+
+- Can `Invoke-SpectreLive` be paused/exited cleanly to hand control to `Read-SpectreSelection`, then resumed?
+- Can command output be captured (e.g., via `Start-Transcript` or stream redirection) and displayed in a right-side panel after the prompt returns?
+- Would Terminal.Gui (full TUI framework) be worth reconsidering despite the testability trade-off?
+- Are there hybrid approaches: static split layout between commands, full-terminal prompt during selection?
+
+### Acceptance Criteria
+
+- [ ] Spike completed: document which approach (if any) is feasible
+- [ ] If feasible: create implementation subtasks with UAT criteria
+- [ ] If not feasible: document why and close as "won't do"
+
+[<- Back to Backlog](README.md)

--- a/docs/backlog/sc-033.md
+++ b/docs/backlog/sc-033.md
@@ -1,0 +1,31 @@
+[<- Back to Backlog](README.md)
+
+# [SC-033] ✅ DONE - Tool-level dependency declaration and installation
+
+**Status**: Done (2026-04-04)
+**Priority**: Medium
+**Component**: `tools/wsl-manager/wsl-manager.ps1`, `lib/wsl/manager.ps1`, `bin/install.ps1`
+**Depends on**: [SC-016a](sc-016a.md)
+
+**Summary**:
+As a tool developer, I want each tool to declare its own dependencies and support installing them via `-InstallDeps`, so that dependency knowledge lives with the tool rather than in the central installer.
+
+**Description**:
+Currently, dependency knowledge is split: `install.ps1` hardcodes `Install-PowerShellModule` for PwshSpectreConsole, while `manager.ps1` throws if the module is missing. This coupling means adding a new tool with dependencies requires editing the central installer.
+
+Phase 1 moves dependency declaration into the tool itself:
+- `manager.ps1` declares its dependencies as a data structure
+- `wsl-manager.ps1` gains an `-InstallDeps` switch that installs declared dependencies
+- `install.ps1` delegates to `wsl-manager.ps1 -InstallDeps` instead of calling `Install-PowerShellModule` directly
+- `manager.ps1` replaces the hard `throw` with an interactive prompt offering to install missing dependencies (auto-detect mode)
+
+### Acceptance Criteria
+
+- [x] `manager.ps1` declares dependencies in a `$script:Dependencies` data structure
+- [x] `wsl-manager.ps1` accepts `-InstallDeps` switch and installs declared dependencies
+- [x] `install.ps1` installs PwshSpectreConsole via `Install-PwshSpectreDependency` (direct delegation not possible — install.ps1 runs under PS 5.1)
+- [x] Interactive auto-detect: missing dependencies prompt user to install (with `Get-UserConfirmation`)
+- [x] CI/test environments skip auto-detect (existing guard preserved)
+- [x] All existing tests pass; new behavior has Pester tests
+
+[<- Back to Backlog](README.md)

--- a/docs/backlog/sc-034.md
+++ b/docs/backlog/sc-034.md
@@ -1,0 +1,30 @@
+[<- Back to Backlog](README.md)
+
+# [SC-034] Shared dependency utilities and auto-discovery
+
+**Status**: Open
+**Priority**: Low
+**Component**: `lib/utils/`, `bin/install.ps1`
+**Depends on**: [SC-033](sc-033.md)
+
+**Summary**:
+As a tool developer, I want shared `Install-ToolDependency` / `Assert-ToolDependency` utilities and automatic tool discovery, so that adding a new tool with dependencies requires zero changes to the central installer.
+
+**Description**:
+Phase 2 generalizes the tool-level dependency pattern introduced in SC-033:
+- Extract shared functions (`Install-ToolDependency`, `Assert-ToolDependency`) into `lib/utils/`
+- Define a standard dependency manifest format (array of hashtables with Name, Type, MinVersion, Repository)
+- Have `install.ps1` discover tool scripts automatically (e.g., scan `tools/*/`) and invoke their `-InstallDeps` switch
+- Support multiple dependency types (PSModule, Scoop package, etc.) in the shared functions
+
+This pays off when a second tool introduces its own dependencies; until then, SC-033's tool-local approach is sufficient.
+
+### Acceptance Criteria
+
+- [ ] `Install-ToolDependency` and `Assert-ToolDependency` exist in `lib/utils/`
+- [ ] Both functions handle at least PSModule dependency type
+- [ ] `install.ps1` discovers tools in `tools/*/` and invokes `-InstallDeps` on each
+- [ ] Dependency manifest format is documented
+- [ ] All existing tests pass; new utilities have Pester tests
+
+[<- Back to Backlog](README.md)

--- a/docs/wsl-manager.md
+++ b/docs/wsl-manager.md
@@ -25,6 +25,7 @@ WSL Manager is a PowerShell tool for managing Windows Subsystem for Linux (WSL) 
 - [DevContainer Setup](#devcontainer-setup)
 - [Technical Reference](#technical-reference)
 - [Additional Resources](#additional-resources)
+- [Architecture](#architecture)
 
 ---
 
@@ -1011,6 +1012,14 @@ export XDG_RUNTIME_DIR=/run/user/$(id -u)
 export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus
 export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
 ```
+
+---
+
+## Architecture
+
+For the planned C4 architecture of the WSL Manager (including Context, Container, and Component diagrams), see:
+
+- [WSL Manager C4 Architecture](architecture/wsl-manager-c4.md)
 
 ---
 

--- a/lib/wsl/manager.Tests.ps1
+++ b/lib/wsl/manager.Tests.ps1
@@ -3,11 +3,21 @@
     Pester tests for manager.ps1
 #>
 
+# Stub parameters are required for Pester ParameterFilter matching but are not used in the stub body
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Stub function parameters are required for Pester ParameterFilter matching')]
 param()
 
 BeforeAll {
     . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
     Start-SutIsolation
+
+    # Define stub functions for PwshSpectreConsole commands so Pester can mock them
+    # without triggering module auto-import (which causes UTF-8 encoding warnings).
+    # manager.ps1 skips Import-Module in test environments, so these stubs provide
+    # the command names that Pester needs for Mock/Should -Invoke.
+    function Read-SpectreSelection { param($Message, $Choices, $PageSize) }
+    function Format-SpectrePanel { param($Border) process { } }
+
     . "$PSScriptRoot\commands.ps1"
     . "$PSScriptRoot\manager.ps1"
 }

--- a/lib/wsl/manager.Tests.ps1
+++ b/lib/wsl/manager.Tests.ps1
@@ -23,7 +23,7 @@ Describe "Show-WslMenu" {
         Show-WslMenu
 
         Should -Invoke Read-SpectreSelection -Times 1 -ParameterFilter {
-            $Message -eq "WSL Manager" -and
+            $Message -eq "Select command" -and
             $Choices -contains "Install new distribution" -and
             $Choices -contains "Remove distribution" -and
             $Choices -contains "Setup Podman" -and

--- a/lib/wsl/manager.Tests.ps1
+++ b/lib/wsl/manager.Tests.ps1
@@ -16,6 +16,46 @@ AfterAll {
     Stop-SutIsolation
 }
 
+Describe "Show-WslMenu" {
+    It "Should call Read-SpectreSelection with menu choices" {
+        Mock Read-SpectreSelection { "Quit" }
+
+        Show-WslMenu
+
+        Should -Invoke Read-SpectreSelection -Times 1 -ParameterFilter {
+            $Message -eq "WSL Manager" -and
+            $Choices -contains "Install new distribution" -and
+            $Choices -contains "Remove distribution" -and
+            $Choices -contains "Setup Podman" -and
+            $Choices -contains "Quit"
+        }
+    }
+
+    It "Should return command string for selected menu option" {
+        Mock Read-SpectreSelection { "Setup Podman" }
+
+        $result = Show-WslMenu
+
+        $result | Should -Be "setup-podman"
+    }
+
+    It "Should return 'quit' when Quit is selected" {
+        Mock Read-SpectreSelection { "Quit" }
+
+        $result = Show-WslMenu
+
+        $result | Should -Be "quit"
+    }
+
+    It "Should return null when user cancels with Ctrl+C" {
+        Mock Read-SpectreSelection { $null }
+
+        $result = Show-WslMenu
+
+        $result | Should -Be $null
+    }
+}
+
 Describe "Start-InteractiveMode" {
     Context "When in CI environment" {
         It "Should display message and exit" {
@@ -32,54 +72,43 @@ Describe "Start-InteractiveMode" {
     Context "When running interactively" {
         BeforeEach {
             Mock Clear-Host {}
+            Mock Read-Host {}
+            Mock Format-SpectrePanel {}
         }
 
-        It "Should display menu options" {
+        It "Should exit when user selects Quit" {
             Mock Test-RunningInCIorTestEnvironment { $false }
-
-            Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
-            } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
-            Mock Read-Host { "Q" }
-
-            Start-InteractiveMode
-
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Install*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Remove*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Setup Podman*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Quit*" }
-        }
-
-        It "Should exit when user selects Q" {
-            Mock Test-RunningInCIorTestEnvironment { $false }
-
             Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
             Mock Write-Host {}
-            Mock Read-Host { "Q" }
+            Mock Show-WslMenu { "quit" }
 
             $result = Start-InteractiveMode
 
             $result | Should -Be $true
         }
 
-        It "Should dispatch to Invoke-WslCommand with 'setup-podman' when P is selected" {
+        It "Should exit when user cancels with Ctrl+C" {
             Mock Test-RunningInCIorTestEnvironment { $false }
+            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
+            Mock Write-Host {}
+            Mock Show-WslMenu { $null }
 
+            $result = Start-InteractiveMode
+
+            $result | Should -Be $true
+        }
+
+        It "Should dispatch to Invoke-WslCommand with 'setup-podman'" {
+            Mock Test-RunningInCIorTestEnvironment { $false }
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
+                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
             } -ParameterFilter { $Detailed }
             Mock Write-Host {}
             $script:callCount = 0
-            Mock Read-Host {
+            Mock Show-WslMenu {
                 $script:callCount++
-                if ($script:callCount -eq 1) { "P" }
-                elseif ($script:callCount -eq 2) { "" }  # Press Enter to continue
-                else { "Q" }
+                if ($script:callCount -eq 1) { "setup-podman" }
+                else { "quit" }
             }
             Mock Invoke-WslCommand {}
 
@@ -88,21 +117,17 @@ Describe "Start-InteractiveMode" {
             Should -Invoke Invoke-WslCommand -ParameterFilter { $Command -eq "setup-podman" } -Times 1
         }
 
-        It "Should dispatch to Invoke-WslCommand with 'setup-devpod' when V is selected" {
+        It "Should dispatch to Invoke-WslCommand with 'setup-devpod'" {
             Mock Test-RunningInCIorTestEnvironment { $false }
-
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
+                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
             } -ParameterFilter { $Detailed }
             Mock Write-Host {}
             $script:callCount = 0
-            Mock Read-Host {
+            Mock Show-WslMenu {
                 $script:callCount++
-                if ($script:callCount -eq 1) { "V" }
-                elseif ($script:callCount -eq 2) { "" }  # Press Enter to continue
-                else { "Q" }
+                if ($script:callCount -eq 1) { "setup-devpod" }
+                else { "quit" }
             }
             Mock Invoke-WslCommand {}
 
@@ -111,21 +136,17 @@ Describe "Start-InteractiveMode" {
             Should -Invoke Invoke-WslCommand -ParameterFilter { $Command -eq "setup-devpod" } -Times 1
         }
 
-        It "Should dispatch to Invoke-WslCommand with 'setup-proxy' when X is selected" {
+        It "Should dispatch to Invoke-WslCommand with 'setup-proxy'" {
             Mock Test-RunningInCIorTestEnvironment { $false }
-
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
+                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
             } -ParameterFilter { $Detailed }
             Mock Write-Host {}
             $script:callCount = 0
-            Mock Read-Host {
+            Mock Show-WslMenu {
                 $script:callCount++
-                if ($script:callCount -eq 1) { "X" }
-                elseif ($script:callCount -eq 2) { "" }  # Press Enter to continue
-                else { "Q" }
+                if ($script:callCount -eq 1) { "setup-proxy" }
+                else { "quit" }
             }
             Mock Invoke-WslCommand {}
 
@@ -134,20 +155,18 @@ Describe "Start-InteractiveMode" {
             Should -Invoke Invoke-WslCommand -ParameterFilter { $Command -eq "setup-proxy" } -Times 1
         }
 
-        It "Should fetch distro list once and pass it to Invoke-WslCommand" {
+        It "Should fetch distro list once per loop and pass it to Invoke-WslCommand" {
             Mock Test-RunningInCIorTestEnvironment { $false }
-
             $mockDistros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
             )
             Mock Get-WslDistroList { $mockDistros } -ParameterFilter { $Detailed }
             Mock Write-Host {}
             $script:callCount = 0
-            Mock Read-Host {
+            Mock Show-WslMenu {
                 $script:callCount++
-                if ($script:callCount -eq 1) { "T" }
-                elseif ($script:callCount -eq 2) { "" }  # Press Enter to continue
-                else { "Q" }
+                if ($script:callCount -eq 1) { "terminate" }
+                else { "quit" }
             }
             Mock Invoke-WslCommand {}
 
@@ -162,12 +181,7 @@ Describe "Start-InteractiveMode" {
             Mock Get-WslDistroList { throw "WSL service not available" } -ParameterFilter { $Detailed }
             Mock Write-Host {}
             Mock Write-ErrorMsg {}
-            $script:callCount = 0
-            Mock Read-Host {
-                $script:callCount++
-                if ($script:callCount -eq 1) { "Q" }
-                else { "Q" }
-            }
+            Mock Show-WslMenu { "quit" }
 
             Start-InteractiveMode
 
@@ -177,43 +191,21 @@ Describe "Start-InteractiveMode" {
         It "Should handle Invoke-WslCommand errors gracefully" {
             Mock Test-RunningInCIorTestEnvironment { $false }
             Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-                )
+                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
             } -ParameterFilter { $Detailed }
             Mock Write-Host {}
             Mock Write-ErrorMsg {}
             Mock Invoke-WslCommand { throw "Command failed" }
             $script:callCount = 0
-            Mock Read-Host {
+            Mock Show-WslMenu {
                 $script:callCount++
-                if ($script:callCount -eq 1) { "I" }
-                elseif ($script:callCount -eq 2) { "" }  # Press Enter to continue
-                else { "Q" }
+                if ($script:callCount -eq 1) { "install" }
+                else { "quit" }
             }
 
             Start-InteractiveMode
 
             Should -Invoke Write-ErrorMsg -ParameterFilter { $Message -like "*Command failed*" }
-        }
-
-        It "Should show error for invalid menu key" {
-            Mock Test-RunningInCIorTestEnvironment { $false }
-            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
-            Mock Write-ErrorMsg {}
-            Mock Start-Sleep {}
-            $script:callCount = 0
-            Mock Read-Host {
-                $script:callCount++
-                if ($script:callCount -eq 1) { "Z" }
-                else { "Q" }
-            }
-
-            Start-InteractiveMode
-
-            Should -Invoke Write-ErrorMsg -ParameterFilter { $Message -like "*Invalid option*" }
-            Should -Invoke Start-Sleep -Times 1
         }
     }
 }

--- a/lib/wsl/manager.Tests.ps1
+++ b/lib/wsl/manager.Tests.ps1
@@ -1627,3 +1627,76 @@ Describe "Invoke-WslManager" {
         }
     }
 }
+
+Describe "Install-WslManagerDependency" {
+    Context "When dependency is already installed" {
+        BeforeAll {
+            Mock Get-InstalledModule { return @{ Name = 'PwshSpectreConsole'; Version = '2.1.0' } } -ParameterFilter { $Name -eq 'PwshSpectreConsole' }
+            Mock Install-Module {}
+            Mock Write-Host {}
+        }
+
+        It "Should skip installation" {
+            Install-WslManagerDependency
+            Should -Not -Invoke Install-Module
+        }
+    }
+
+    Context "When dependency is missing and NuGet is available" {
+        BeforeAll {
+            Mock Get-InstalledModule { $null } -ParameterFilter { $Name -eq 'PwshSpectreConsole' }
+            Mock Get-PackageProvider { return @{ Name = 'NuGet' } } -ParameterFilter { $Name -eq 'NuGet' }
+            Mock Install-PackageProvider {}
+            Mock Install-Module {}
+            Mock Write-Host {}
+        }
+
+        It "Should install PwshSpectreConsole from PSGallery" {
+            Install-WslManagerDependency
+            Should -Invoke Install-Module -Times 1 -ParameterFilter {
+                $Name -eq 'PwshSpectreConsole' -and
+                $Repository -eq 'PSGallery' -and
+                $Scope -eq 'CurrentUser' -and
+                $MinimumVersion -eq '2.0'
+            }
+        }
+
+        It "Should not install NuGet provider" {
+            Install-WslManagerDependency
+            Should -Not -Invoke Install-PackageProvider
+        }
+    }
+
+    Context "When NuGet provider is missing" {
+        BeforeAll {
+            Mock Get-InstalledModule { $null } -ParameterFilter { $Name -eq 'PwshSpectreConsole' }
+            Mock Get-PackageProvider { $null } -ParameterFilter { $Name -eq 'NuGet' }
+            Mock Install-PackageProvider {}
+            Mock Install-Module {}
+            Mock Write-Host {}
+        }
+
+        It "Should install NuGet provider before the module" {
+            Install-WslManagerDependency
+            Should -Invoke Install-PackageProvider -Times 1 -ParameterFilter {
+                $Name -eq 'NuGet' -and
+                $Scope -eq 'CurrentUser'
+            }
+            Should -Invoke Install-Module -Times 1
+        }
+    }
+}
+
+Describe "Dependency auto-detect" {
+    # These tests verify the module-load guard behavior in manager.ps1 top-level code.
+    # The guard runs at dot-source time, so we test via the $script:Dependencies declaration.
+
+    It "Should declare PwshSpectreConsole in Dependencies" {
+        $script:Dependencies | Should -Not -BeNullOrEmpty
+        $dep = $script:Dependencies | Where-Object { $_.Name -eq 'PwshSpectreConsole' }
+        $dep | Should -Not -BeNullOrEmpty
+        $dep.Type | Should -Be 'PSModule'
+        $dep.MinVersion | Should -Be '2.0'
+        $dep.Repository | Should -Be 'PSGallery'
+    }
+}

--- a/lib/wsl/manager.Tests.ps1
+++ b/lib/wsl/manager.Tests.ps1
@@ -15,7 +15,7 @@ BeforeAll {
     # without triggering module auto-import (which causes UTF-8 encoding warnings).
     # manager.ps1 skips Import-Module in test environments, so these stubs provide
     # the command names that Pester needs for Mock/Should -Invoke.
-    function Read-SpectreSelection { param($Message, $Choices, $PageSize) }
+    function Read-SpectreSelection { param($Message, $Choices, $PageSize, [switch]$EnableSearch) }
     function Format-SpectrePanel { param($Border) process { } }
 
     . "$PSScriptRoot\commands.ps1"
@@ -37,7 +37,8 @@ Describe "Show-WslMenu" {
             $Choices -contains "Install new distribution" -and
             $Choices -contains "Remove distribution" -and
             $Choices -contains "Setup Podman" -and
-            $Choices -contains "Quit"
+            $Choices -contains "Quit" -and
+            $EnableSearch -eq $true
         }
     }
 

--- a/lib/wsl/manager.ps1
+++ b/lib/wsl/manager.ps1
@@ -11,6 +11,40 @@ param()
 # Source dependencies
 . "$PSScriptRoot\commands.ps1"
 
+# Dependency declaration (SC-033): each tool owns its dependency list
+$script:Dependencies = @(
+    @{ Name = 'PwshSpectreConsole'; Type = 'PSModule'; MinVersion = '2.0'; Repository = 'PSGallery' }
+)
+
+function Install-WslManagerDependency {
+    <#
+    .SYNOPSIS
+        Installs all declared dependencies for WSL Manager.
+    .DESCRIPTION
+        Iterates over $script:Dependencies and installs any missing PSModule dependencies.
+        Called by wsl-manager.ps1 -InstallDeps or by the auto-detect prompt.
+    #>
+    [CmdletBinding()]
+    param()
+
+    foreach ($dep in $script:Dependencies) {
+        if ($dep.Type -eq 'PSModule') {
+            if (-not (Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction SilentlyContinue)) {
+                Write-Status "Installing NuGet package provider..."
+                Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -Scope CurrentUser
+            }
+            if (Get-InstalledModule -Name $dep.Name -MinimumVersion $dep.MinVersion -ErrorAction SilentlyContinue) {
+                Write-Status "$($dep.Name) is already installed"
+            }
+            else {
+                Write-Status "Installing $($dep.Name)..."
+                Install-Module -Name $dep.Name -Repository $dep.Repository -Scope CurrentUser -Force -MinimumVersion $dep.MinVersion -SkipPublisherCheck
+                Write-Success "$($dep.Name) installed"
+            }
+        }
+    }
+}
+
 # Import PwshSpectreConsole for TUI primitives (SC-016)
 # Skip in CI/test environments where the module is mocked
 if (-not (Test-RunningInCIorTestEnvironment)) {
@@ -18,7 +52,13 @@ if (-not (Test-RunningInCIorTestEnvironment)) {
     $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
 
     if (-not (Get-Module -Name PwshSpectreConsole -ListAvailable)) {
-        throw "PwshSpectreConsole module is not installed. Run bin/install.ps1 to set up dependencies."
+        $install = Get-UserConfirmation -message "PwshSpectreConsole module is missing. Install now?"
+        if ($install) {
+            Install-WslManagerDependency
+        }
+        else {
+            throw "PwshSpectreConsole module is required. Run bin/install.ps1 or relaunch and accept the install prompt."
+        }
     }
     Import-Module PwshSpectreConsole -ErrorAction Stop
 }

--- a/lib/wsl/manager.ps1
+++ b/lib/wsl/manager.ps1
@@ -14,10 +14,49 @@ param()
 # Import PwshSpectreConsole for TUI primitives (SC-016)
 # Skip in CI/test environments where the module is mocked
 if (-not (Test-RunningInCIorTestEnvironment)) {
+    # Enable UTF-8 encoding for Spectre.Console (avoids "Western European (DOS)" warning)
+    $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+
     if (-not (Get-Module -Name PwshSpectreConsole -ListAvailable)) {
         throw "PwshSpectreConsole module is not installed. Run bin/install.ps1 to set up dependencies."
     }
     Import-Module PwshSpectreConsole -ErrorAction Stop
+}
+
+function Show-WslMenu {
+    <#
+    .SYNOPSIS
+        Displays the main menu using Read-SpectreSelection and returns the selected command.
+    .OUTPUTS
+        The command string (e.g. "install", "remove") or $null if the user cancels (Ctrl+C).
+    #>
+    [CmdletBinding()]
+    param()
+
+    # Menu choices: label -> command mapping
+    $menuChoices = [ordered]@{
+        "Install new distribution"      = "install"
+        "Clone distribution"            = "clone"
+        "Update distribution"           = "update"
+        "Setup user account"            = "setup-user"
+        "Setup Docker"                  = "setup-docker"
+        "Setup Podman"                  = "setup-podman"
+        "Setup DevPod"                  = "setup-devpod"
+        "Setup proxy (corporate)"       = "setup-proxy"
+        "Remove distribution"           = "remove"
+        "Terminate distribution"        = "terminate"
+        "Shutdown WSL"                  = "shutdown"
+        "Configure .wslconfig defaults" = "configure-wsl"
+        "Quit"                          = "quit"
+    }
+
+    $selection = Read-SpectreSelection -Message "WSL Manager" -Choices $menuChoices.Keys -PageSize 14
+
+    if ($null -eq $selection) {
+        return $null
+    }
+
+    return $menuChoices[$selection]
 }
 
 function Start-InteractiveMode {
@@ -36,28 +75,10 @@ function Start-InteractiveMode {
         return $false
     }
 
-    # Map menu keys to command names
-    $menuKeyMap = @{
-        "I" = "install"
-        "C" = "clone"
-        "U" = "update"
-        "S" = "setup-user"
-        "D" = "setup-docker"
-        "P" = "setup-podman"
-        "V" = "setup-devpod"
-        "X" = "setup-proxy"
-        "R" = "remove"
-        "T" = "terminate"
-        "H" = "shutdown"
-        "W" = "configure-wsl"
-    }
-
     $continue = $true
     while ($continue) {
         Clear-Host
-        Write-Host "============================================" -ForegroundColor Cyan
-        Write-Host "  WSL Manager" -ForegroundColor Cyan
-        Write-Host "============================================" -ForegroundColor Cyan
+        "[cyan]WSL Manager[/]" | Format-SpectrePanel -Border Rounded
 
         # Fetch current distributions once per loop iteration and display the table.
         # The fetched list is passed to action functions so they use consistent numbering
@@ -72,31 +93,12 @@ function Start-InteractiveMode {
             Write-Host ""
         }
 
-        # Show menu
-        Write-Host "Commands:" -ForegroundColor Cyan
-        Write-Host "  [I] Install new distribution" -ForegroundColor White
-        Write-Host "  [C] Clone distribution" -ForegroundColor White
-        Write-Host "  [U] Update distribution" -ForegroundColor White
-        Write-Host "  [S] Setup user account" -ForegroundColor White
-        Write-Host "  [D] Setup Docker" -ForegroundColor White
-        Write-Host "  [P] Setup Podman" -ForegroundColor White
-        Write-Host "  [V] Setup DevPod" -ForegroundColor White
-        Write-Host "  [X] Setup proxy (corporate)" -ForegroundColor White
-        Write-Host "  [R] Remove distribution" -ForegroundColor White
-        Write-Host "  [T] Terminate distribution" -ForegroundColor White
-        Write-Host "  [H] Shutdown WSL" -ForegroundColor White
-        Write-Host "  [W] Configure .wslconfig defaults" -ForegroundColor White
-        Write-Host "  [Q] Quit" -ForegroundColor White
-        Write-Host ""
+        $command = Show-WslMenu
 
-        $choice = Read-Host "Select command"
-        $key = $choice.ToUpper()
-
-        if ($key -eq "Q") {
+        if ($null -eq $command -or $command -eq "quit") {
             $continue = $false
         }
-        elseif ($menuKeyMap.ContainsKey($key)) {
-            $command = $menuKeyMap[$key]
+        else {
             if ($PSCmdlet.ShouldProcess($command, "Execute WSL command")) {
                 try {
                     Invoke-WslCommand -Command $command -Distros $menuDistros
@@ -104,12 +106,8 @@ function Start-InteractiveMode {
                 catch {
                     Write-ErrorMsg "$_"
                 }
+                Read-Host -Prompt "Press Enter to continue"
             }
-            Read-Host -Prompt "Press Enter to continue ..."
-        }
-        else {
-            Write-ErrorMsg "Invalid option. Please try again."
-            Start-Sleep -Seconds 1
         }
     }
 

--- a/lib/wsl/manager.ps1
+++ b/lib/wsl/manager.ps1
@@ -50,7 +50,7 @@ function Show-WslMenu {
         "Quit"                          = "quit"
     }
 
-    $selection = Read-SpectreSelection -Message "WSL Manager" -Choices $menuChoices.Keys -PageSize 14
+    $selection = Read-SpectreSelection -Message "Select command" -Choices $menuChoices.Keys -PageSize 14
 
     if ($null -eq $selection) {
         return $null

--- a/lib/wsl/manager.ps1
+++ b/lib/wsl/manager.ps1
@@ -50,7 +50,7 @@ function Show-WslMenu {
         "Quit"                          = "quit"
     }
 
-    $selection = Read-SpectreSelection -Message "Select command" -Choices $menuChoices.Keys -PageSize 14
+    $selection = Read-SpectreSelection -Message "Select command" -Choices $menuChoices.Keys -PageSize 14 -EnableSearch
 
     if ($null -eq $selection) {
         return $null

--- a/lib/wsl/manager.ps1
+++ b/lib/wsl/manager.ps1
@@ -11,6 +11,15 @@ param()
 # Source dependencies
 . "$PSScriptRoot\commands.ps1"
 
+# Import PwshSpectreConsole for TUI primitives (SC-016)
+# Skip in CI/test environments where the module is mocked
+if (-not (Test-RunningInCIorTestEnvironment)) {
+    if (-not (Get-Module -Name PwshSpectreConsole -ListAvailable)) {
+        throw "PwshSpectreConsole module is not installed. Run bin/install.ps1 to set up dependencies."
+    }
+    Import-Module PwshSpectreConsole -ErrorAction Stop
+}
+
 function Start-InteractiveMode {
     <#
     .SYNOPSIS

--- a/tools/wsl-manager/wsl-manager.ps1
+++ b/tools/wsl-manager/wsl-manager.ps1
@@ -53,6 +53,9 @@
     .\wsl-manager.ps1 install Ubuntu-22.04
     Installs an Ubuntu 22.04 LTS distribution.
 
+.PARAMETER InstallDeps
+    Install declared tool dependencies and exit. Used by bin/install.ps1 and automation.
+
 .PARAMETER Username
     The username to create (used with setup-user command).
     If not provided, the user is prompted interactively.
@@ -90,9 +93,16 @@ param(
     [string]$TargetName = "",
 
     [string]$Username = "",
-    [string]$Password = ""
+    [string]$Password = "",
+
+    [switch]$InstallDeps
 )
 
 . "$PSScriptRoot\..\..\lib\wsl\manager.ps1"
+
+if ($InstallDeps) {
+    Install-WslManagerDependency
+    return
+}
 
 Invoke-WslManager -Command $Command -Name $Name -TargetName $TargetName -Username $Username -Password $Password


### PR DESCRIPTION
## Summary

- Replace `Write-Host`-based distro list (`Format-DistroListEntry` + `Show-WslDistroList`) with a Spectre.Console rich table (`Show-WslDistroTable`) using `Format-SpectreTable -Expand`
- Wrap the distro table in a branded `Get-WslManagerPanel` with dark blue rounded border and "WSL Manager" header
- Color-coded status: `[green]Running[/]`, `[grey]Stopped[/]`, default marker `[green]*[/]`
- Remove old formatting functions; update all callers and tests
- Add PwshSpectreConsole stubs in unit and integration test files for CI compatibility

Closes SC-016c.

## Changes

| File | What changed |
|------|-------------|
| `lib/wsl/commands.ps1` | Replace `Format-DistroListEntry` + `Show-WslDistroList` with `Show-WslDistroTable`; update `Select-WslDistro` and `Invoke-WslCommand` callers |
| `lib/wsl/manager.ps1` | Add `Get-WslManagerPanel`; refactor `Start-InteractiveMode` to use single panel layout |
| `lib/wsl/commands.Tests.ps1` | Rewrite tests for new table-based display; add `Format-SpectreTable` stub |
| `lib/wsl/manager.Tests.ps1` | Add `Get-WslManagerPanel` tests; update stubs for new Spectre cmdlets |
| `lib/wsl/manager.docker.Integration.Tests.ps1` | Add conditional PwshSpectreConsole stubs for CI |
| `docs/backlog/sc-016c.md` | Update spec to reflect single-panel design; mark all ACs done |
| `docs/images/shortcuts_logo_terminal/draw.ps1` | Add Spectre markup logo script |

## Test plan

- [x] Unit tests pass: 111 (commands) + 118 (manager) = 229 total, 0 failures
- [x] PSScriptAnalyzer lint clean
- [x] Manual: run `Invoke-WslManager` interactively and verify table renders with colored status, default marker, and panel border

🤖 Generated with [Claude Code](https://claude.com/claude-code)