### PR TITLE
feat: replace distro list with Spectre table and add branding panel (SC-016c)

### DIFF
--- a/docs/backlog/sc-016c.md
+++ b/docs/backlog/sc-016c.md
@@ -9,21 +9,29 @@
 **Depends on**: [SC-016a](sc-016a.md)
 
 **Summary**:
-As a user, I want the distribution list displayed as a rich bordered table with color-coded status, alongside a command output panel, so that I can see both distribution state and recent command results above the menu prompt.
+As a user, I want the distribution list displayed as a rich bordered table with color-coded status, alongside a branding panel with the shortcuts logo, Tux ASCII art, FigletText title, and slogan, so that I can see both distribution state and project branding above the menu prompt.
 
 **Description**:
 Replace `Show-WslDistroList` + `Format-DistroListEntry` with a new `Show-WslDistroTable` function using `Format-SpectreTable`. Status values use Spectre markup for coloring: `[green]Running[/]`, `[grey]Stopped[/]`.
 
-Add a two-column layout above the `Read-SpectreSelection` menu prompt using `New-SpectreLayout -Columns`: the left panel shows the distro table, the right panel shows the last command's console output. Both panels use `Format-SpectrePanel` with borders and take roughly half the terminal width.
+Add a two-column layout above the `Read-SpectreSelection` menu prompt using `New-SpectreLayout -Columns`: the left panel shows the distro table, the right panel shows the WSL Manager branding. Both panels use `Format-SpectrePanel` with borders and take roughly half the terminal width.
+
+The right panel contains:
+- **Shortcuts logo** as colored ASCII art (4-quadrant block pattern)
+- **Tux** (Linux penguin) as ASCII art
+- **"WSL Manager"** rendered as FigletText via `Write-SpectreFigletText`
+- **Slogan**: "Your DevOps environment at ease!" in italic
 
 ```
-+-- Distributions ---------------+ +-- Output ----------------------+
-|  # Name        State    Ver    | | V Terminated 'ubu-dev'         |
-|  1 Ubuntu      Running  WSL2   | |                                |
-|  2 ubu-dev     Stopped  WSL2   | |                                |
-+--------------------------------+ +--------------------------------+
++-- Distributions ---------------+ +-------------------------------+
+|  # Name        State    Ver    | |  ████████     .--.            |
+|  1 Ubuntu      Running  WSL2   | |  ████████    |o_o |           |
+|  2 ubu-dev     Stopped  WSL2   | |  ████████    |:_/ |           |
+|                                | |              //   \ \         |
+|                                | |  WSL Manager (FigletText)     |
+|                                | |  Your DevOps environment ...  |
++--------------------------------+ +-------------------------------+
 
-WSL Manager
 > Install new distribution
   Clone distribution
   ...
@@ -35,22 +43,30 @@ WSL Manager
 - Columns: #, Name, State (color-coded), Version (WSL1/WSL2), Default
 - Keep the same `-Distros` parameter signature as `Show-WslDistroList`
 - Remove `Format-DistroListEntry` and `Show-WslDistroList` (replaced)
+- Update `Select-WslDistro` to use `Show-WslDistroTable` for display
+- Create `Get-WslBrandingPanel` in `manager.ps1`:
+  - Shortcuts logo as colored block ASCII art (4 quadrants: blue, orange, green, pink)
+  - Tux ASCII art (classic penguin)
+  - Logo and Tux side by side via `Format-SpectreColumns`
+  - `Write-SpectreFigletText -Text "WSL Manager" -Alignment Center -Color "DeepSkyBlue1" -PassThru`
+  - Slogan as italic Spectre markup
+  - All composed vertically via `Format-SpectreRows`
 - In `manager.ps1`, build a two-column layout with `New-SpectreLayout -Columns`:
   - Left: distro table in a `Format-SpectrePanel` with header "Distributions"
-  - Right: last command output in a `Format-SpectrePanel` with header "Output"
-- Capture command output (via `-OutVariable` or stream redirection) and display in the right panel on next loop iteration
+  - Right: branding panel in a `Format-SpectrePanel`
 - Replace the single `Format-SpectrePanel` header with the two-column layout
 - Update tests in both `commands.Tests.ps1` and `manager.Tests.ps1`
-- Mock `Format-SpectreTable`, `New-SpectreLayout`, `Format-SpectrePanel` in tests
+- Mock `Format-SpectreTable`, `New-SpectreLayout`, `Format-SpectrePanel`, `Format-SpectreRows`, `Format-SpectreColumns`, `Write-SpectreFigletText` in tests
 
 **Acceptance Criteria**:
 - [ ] Distro table rendered with `Format-SpectreTable` (borders, alignment)
 - [ ] Running distros show `[green]Running[/]`, stopped show `[grey]Stopped[/]`
 - [ ] Default distro is visually marked in the table
 - [ ] "No WSL distributions found" message still shown when empty
-- [ ] Two-column layout: distro table (left) and command output (right) above the menu
-- [ ] Command output panel shows the result of the last executed command
+- [ ] Two-column layout: distro table (left) and branding (right) above the menu
+- [ ] Branding panel shows shortcuts logo ASCII art, Tux ASCII art, FigletText "WSL Manager", and slogan
 - [ ] `Show-WslDistroTable` has Pester unit tests with mocked Spectre cmdlets
+- [ ] `Get-WslBrandingPanel` has Pester unit tests with mocked Spectre cmdlets
 - [ ] All existing tests continue to pass (updated references)
 
 [<- Back to Backlog](README.md)

--- a/docs/backlog/sc-016c.md
+++ b/docs/backlog/sc-016c.md
@@ -2,7 +2,7 @@
 
 # [SC-016c] Replace distro table with Format-SpectreTable and add split-panel layout
 
-**Status**: Open
+**Status**: Done
 **Priority**: High
 **Component**: `lib/wsl/commands.ps1`, `lib/wsl/commands.Tests.ps1`, `lib/wsl/manager.ps1`, `lib/wsl/manager.Tests.ps1`
 **Parent**: [SC-016](sc-016.md)
@@ -59,14 +59,14 @@ The right panel contains:
 - Mock `Format-SpectreTable`, `New-SpectreLayout`, `Format-SpectrePanel`, `Format-SpectreRows`, `Format-SpectreColumns`, `Write-SpectreFigletText` in tests
 
 **Acceptance Criteria**:
-- [ ] Distro table rendered with `Format-SpectreTable` (borders, alignment)
-- [ ] Running distros show `[green]Running[/]`, stopped show `[grey]Stopped[/]`
-- [ ] Default distro is visually marked in the table
-- [ ] "No WSL distributions found" message still shown when empty
-- [ ] Two-column layout: distro table (left) and branding (right) above the menu
-- [ ] Branding panel shows shortcuts logo ASCII art, Tux ASCII art, FigletText "WSL Manager", and slogan
-- [ ] `Show-WslDistroTable` has Pester unit tests with mocked Spectre cmdlets
-- [ ] `Get-WslBrandingPanel` has Pester unit tests with mocked Spectre cmdlets
-- [ ] All existing tests continue to pass (updated references)
+- [x] Distro table rendered with `Format-SpectreTable` (borders, alignment)
+- [x] Running distros show `[green]Running[/]`, stopped show `[grey]Stopped[/]`
+- [x] Default distro is visually marked in the table
+- [x] "No WSL distributions found" message still shown when empty
+- [x] Two-column layout: distro table (left) and branding (right) above the menu
+- [x] Branding panel shows shortcuts logo ASCII art, Tux ASCII art, FigletText "WSL Manager", and slogan
+- [x] `Show-WslDistroTable` has Pester unit tests with mocked Spectre cmdlets
+- [x] `Get-WslBrandingPanel` has Pester unit tests with mocked Spectre cmdlets
+- [x] All existing tests continue to pass (updated references)
 
 [<- Back to Backlog](README.md)

--- a/lib/wsl/commands.Tests.ps1
+++ b/lib/wsl/commands.Tests.ps1
@@ -8,6 +8,10 @@ param()
 BeforeAll {
     . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
     Start-SutIsolation
+
+    # Stub PwshSpectreConsole commands used by commands.ps1
+    function Format-SpectreTable { param($Border, $Color, [switch]$AllowMarkup) process { } }
+
     . "$PSScriptRoot\commands.ps1"
 }
 
@@ -15,211 +19,69 @@ AfterAll {
     Stop-SutIsolation
 }
 
-Describe "Format-DistroListEntry" {
-    BeforeEach {
-        Mock Write-Host {}
-    }
-
-    It "Should display index number" {
-        $distro = [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false }
-
-        Format-DistroListEntry -Index 1 -Distro $distro
-
-        Should -Invoke Write-Host -ParameterFilter { $Object -like "*1.*" }
-    }
-
-    It "Should display distribution name" {
-        $distro = [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false }
-
-        Format-DistroListEntry -Index 1 -Distro $distro
-
-        Should -Invoke Write-Host -ParameterFilter { $Object -like "*Debian*" }
-    }
-
-    It "Should use green color for running state" {
-        $distro = [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false }
-
-        Format-DistroListEntry -Index 1 -Distro $distro
-
-        Should -Invoke Write-Host -ParameterFilter { $ForegroundColor -eq "Green" -and $Object -like "*Running*" }
-    }
-
-    It "Should use gray color for stopped state" {
-        $distro = [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
-
-        Format-DistroListEntry -Index 1 -Distro $distro
-
-        Should -Invoke Write-Host -ParameterFilter { $ForegroundColor -eq "Gray" -and $Object -like "*Stopped*" }
-    }
-
-    It "Should include Default indicator for default distribution" {
-        $distro = [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
-
-        Format-DistroListEntry -Index 1 -Distro $distro
-
-        Should -Invoke Write-Host -ParameterFilter { $Object -like "*Default*" }
-    }
-
-    It "Should not include Default indicator for non-default distribution" {
-        $distro = [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false }
-
-        Format-DistroListEntry -Index 1 -Distro $distro
-
-        Should -Invoke Write-Host -ParameterFilter { $Object -like "*Default*" } -Times 0
-    }
-
-    It "Should display WSL version number" {
-        $distro = [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 1; IsDefault = $false }
-
-        Format-DistroListEntry -Index 1 -Distro $distro
-
-        Should -Invoke Write-Host -ParameterFilter { $Object -like "*WSL1*" }
-    }
-}
-
-Describe "Show-WslDistroList" {
-    Context "When WSL is installed" {
+Describe "Show-WslDistroTable" {
+    Context "When distributions exist" {
         BeforeEach {
-            Mock Write-Host {}
+            Mock Format-SpectreTable { "mocked-table" }
         }
 
-        It "Should display message when no distributions are installed" {
-            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
-
-            Show-WslDistroList
-
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*No WSL distributions*" }
-        }
-
-        It "Should call Get-WslDistroList with -Detailed switch" {
-            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
-
-            Show-WslDistroList
-
-            Should -Invoke Get-WslDistroList -ParameterFilter { $Detailed -eq $true } -Times 1
-        }
-
-        It "Should display distribution name and state" {
-            Mock Get-WslDistroList {
-                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
-            } -ParameterFilter { $Detailed }
-
-            Show-WslDistroList
-
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Debian*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Running*" }
-        }
-
-        It "Should display state with green color when running" {
-            Mock Get-WslDistroList {
-                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false })
-            } -ParameterFilter { $Detailed }
-
-            Show-WslDistroList
-
-            Should -Invoke Write-Host -ParameterFilter {
-                $ForegroundColor -eq "Green" -and $Object -like "*Running*"
-            }
-        }
-
-        It "Should display state with gray color when stopped" {
-            Mock Get-WslDistroList {
-                @([PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false })
-            } -ParameterFilter { $Detailed }
-
-            Show-WslDistroList
-
-            Should -Invoke Write-Host -ParameterFilter {
-                $ForegroundColor -eq "Gray" -and $Object -like "*Stopped*"
-            }
-        }
-
-        It "Should display WSL version" {
-            Mock Get-WslDistroList {
-                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false })
-            } -ParameterFilter { $Detailed }
-
-            Show-WslDistroList
-
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*WSL2*" }
-        }
-
-        It "Should display default indicator for default distribution" {
-            Mock Get-WslDistroList {
-                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
-            } -ParameterFilter { $Detailed }
-
-            Show-WslDistroList
-
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Default*" }
-        }
-
-        It "Should handle mixed running and stopped distributions" {
-            Mock Get-WslDistroList {
-                @(
-                    [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true },
-                    [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
-                )
-            } -ParameterFilter { $Detailed }
-
-            Show-WslDistroList
-
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Debian*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Ubuntu*" }
-            Should -Invoke Write-Host -ParameterFilter {
-                $ForegroundColor -eq "Green" -and $Object -like "*Running*"
-            }
-            Should -Invoke Write-Host -ParameterFilter {
-                $ForegroundColor -eq "Gray" -and $Object -like "*Stopped*"
-            }
-        }
-
-        It "Should display header" {
-            Mock Get-WslDistroList {
-                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $false })
-            } -ParameterFilter { $Detailed }
-
-            Show-WslDistroList
-
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Installed*Distributions*" }
-        }
-    }
-
-    Context "When pre-fetched Distros are provided" {
-        BeforeEach {
-            Mock Get-WslDistroList {}
-            Mock Write-Host {}
-        }
-
-        It "Should use provided distros and not call Get-WslDistroList" {
+        It "Should call Format-SpectreTable with Rounded border and AllowMarkup" {
             $distros = @(
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
             )
 
-            Show-WslDistroList -Distros $distros
+            Show-WslDistroTable -Distros $distros
 
-            Should -Invoke Get-WslDistroList -Times 0
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Debian*" }
+            Should -Invoke Format-SpectreTable -ParameterFilter {
+                $Border -eq "Rounded" -and $Color -eq "Cyan" -and $AllowMarkup -eq $true
+            }
         }
 
-        It "Should display provided distros without re-fetching" {
+        It "Should fetch distros when not provided" {
+            Mock Get-WslDistroList {
+                @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
+            } -ParameterFilter { $Detailed }
+
+            Show-WslDistroTable
+
+            Should -Invoke Get-WslDistroList -ParameterFilter { $Detailed -eq $true } -Times 1
+            Should -Invoke Format-SpectreTable -Times 1
+        }
+
+        It "Should use provided distros without fetching" {
+            Mock Get-WslDistroList {}
             $distros = @(
-                [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false },
-                [PSCustomObject]@{ Name = "Fedora"; State = "Running"; Version = 2; IsDefault = $false }
+                [PSCustomObject]@{ Name = "Ubuntu"; State = "Stopped"; Version = 2; IsDefault = $false }
             )
 
-            Show-WslDistroList -Distros $distros
+            Show-WslDistroTable -Distros $distros
 
             Should -Invoke Get-WslDistroList -Times 0
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Ubuntu*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Fedora*" }
+            Should -Invoke Format-SpectreTable -Times 1
+        }
+    }
+
+    Context "When no distributions exist" {
+        It "Should return no-distributions message when empty" {
+            $result = Show-WslDistroTable -Distros @()
+
+            $result | Should -BeLike "*No WSL distributions*"
         }
 
-        It "Should display no-distributions message when provided empty list" {
-            Show-WslDistroList -Distros @()
+        It "Should return no-distributions message when fetched list is empty" {
+            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
 
-            Should -Invoke Get-WslDistroList -Times 0
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*No WSL distributions*" }
+            $result = Show-WslDistroTable
+
+            $result | Should -BeLike "*No WSL distributions*"
+        }
+
+        It "Should not call Format-SpectreTable when empty" {
+            Mock Format-SpectreTable {}
+
+            Show-WslDistroTable -Distros @()
+
+            Should -Invoke Format-SpectreTable -Times 0
         }
     }
 }
@@ -355,7 +217,7 @@ Describe "Select-WslDistro" {
 
     Context "Table display logic" {
         BeforeEach {
-            Mock Write-Host {}
+            Mock Format-SpectreTable { "mocked-table" }
             Mock Read-Host { "1" }
         }
 
@@ -366,8 +228,7 @@ Describe "Select-WslDistro" {
 
             Select-WslDistro
 
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Available distributions*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Debian*" }
+            Should -Invoke Format-SpectreTable -Times 1
         }
 
         It "Should not show the table when Distros are pre-fetched" {
@@ -377,7 +238,7 @@ Describe "Select-WslDistro" {
 
             Select-WslDistro -Distros $distros
 
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Available distributions*" } -Times 0
+            Should -Invoke Format-SpectreTable -Times 0
         }
 
         It "Should not call Get-WslDistroList when Distros are pre-fetched" {
@@ -395,12 +256,12 @@ Describe "Select-WslDistro" {
 
 Describe "Invoke-WslCommand" {
     Context "When dispatching commands" {
-        It "Should dispatch 'list' to Show-WslDistroList" {
-            Mock Show-WslDistroList {}
+        It "Should dispatch 'list' to Show-WslDistroTable" {
+            Mock Show-WslDistroTable {}
 
             Invoke-WslCommand -Command "list"
 
-            Should -Invoke Show-WslDistroList -Times 1
+            Should -Invoke Show-WslDistroTable -Times 1
         }
 
         It "Should dispatch 'install' with Name parameter" {
@@ -510,13 +371,13 @@ Describe "Invoke-WslCommand" {
             Should -Invoke Invoke-TerminateDistro -ParameterFilter { $null -ne $Distros }
         }
 
-        It "Should pass Distros to Show-WslDistroList for list command" {
+        It "Should pass Distros to Show-WslDistroTable for list command" {
             $testDistros = @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
-            Mock Show-WslDistroList {}
+            Mock Show-WslDistroTable {}
 
             Invoke-WslCommand -Command "list" -Distros $testDistros
 
-            Should -Invoke Show-WslDistroList -ParameterFilter { $null -ne $Distros }
+            Should -Invoke Show-WslDistroTable -ParameterFilter { $null -ne $Distros }
         }
     }
 }

--- a/lib/wsl/commands.Tests.ps1
+++ b/lib/wsl/commands.Tests.ps1
@@ -3,8 +3,6 @@
     Pester tests for commands.ps1
 #>
 
-# Stub parameters are required for Pester ParameterFilter matching but are not used in the stub body
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Stub function parameters are required for Pester ParameterFilter matching')]
 param()
 
 BeforeAll {
@@ -12,7 +10,7 @@ BeforeAll {
     Start-SutIsolation
 
     # Stub PwshSpectreConsole commands used by commands.ps1
-    function Format-SpectreTable { param($Border, $Color, [switch]$AllowMarkup) process { } }
+    function Format-SpectreTable { param($Border, $Color, [switch]$AllowMarkup) process { $null = $Border, $Color, $AllowMarkup; $_ } }
 
     . "$PSScriptRoot\commands.ps1"
 }

--- a/lib/wsl/commands.Tests.ps1
+++ b/lib/wsl/commands.Tests.ps1
@@ -3,6 +3,8 @@
     Pester tests for commands.ps1
 #>
 
+# Stub parameters are required for Pester ParameterFilter matching but are not used in the stub body
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Stub function parameters are required for Pester ParameterFilter matching')]
 param()
 
 BeforeAll {
@@ -613,12 +615,11 @@ Describe "Invoke-TerminateDistro" {
 
         It "Should list all distributions (not just running)" {
             Mock Read-Host { "1" }
+            Mock Show-WslDistroTable {}
 
             Invoke-TerminateDistro
 
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Debian*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Ubuntu*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Alpine*" }
+            Should -Invoke Show-WslDistroTable -Times 1
         }
 
         It "Should handle selection by number (1)" {

--- a/lib/wsl/commands.ps1
+++ b/lib/wsl/commands.ps1
@@ -20,43 +20,16 @@ $ErrorActionPreference = "Stop"
 
 #region Functions
 
-function Format-DistroListEntry {
+function Show-WslDistroTable {
     <#
     .SYNOPSIS
-        Formats a distribution list entry with state information.
-
-    .PARAMETER Index
-        The index number to display.
-
-    .PARAMETER Distro
-        The distribution object with Name, State, Version, and IsDefault properties.
-    #>
-    param(
-        [int]$Index,
-        [PSCustomObject]$Distro
-    )
-
-    $statusParts = @()
-    $statusParts += $Distro.State
-    $statusParts += "WSL$($Distro.Version)"
-    if ($Distro.IsDefault) {
-        $statusParts += "Default"
-    }
-    $status = $statusParts -join ", "
-
-    $stateColor = if ($Distro.State -eq "Running") { "Green" } else { "Gray" }
-    Write-Host "  $Index. " -NoNewline -ForegroundColor White
-    Write-Host "$($Distro.Name) " -NoNewline -ForegroundColor White
-    Write-Host "($status)" -ForegroundColor $stateColor
-}
-
-function Show-WslDistroList {
-    <#
-    .SYNOPSIS
-        Displays a list of installed WSL distributions with state information.
+        Displays installed WSL distributions as a formatted Spectre table.
 
     .PARAMETER Distros
         Optional pre-fetched list of distributions. If not provided, fetches from WSL.
+
+    .OUTPUTS
+        A Spectre renderable table object, or a markup string when no distributions are found.
     #>
     param(
         [PSCustomObject[]]$Distros = $null
@@ -66,21 +39,25 @@ function Show-WslDistroList {
         $Distros = @(Get-WslDistroList -Detailed)
     }
 
-    Write-Host ""
-    Write-Host "Installed WSL Distributions:" -ForegroundColor Cyan
-    Write-Host "-----------------------------" -ForegroundColor Cyan
-
     if ($Distros.Count -eq 0) {
-        Write-Host "  No WSL distributions found." -ForegroundColor Yellow
+        return "[yellow]No WSL distributions found.[/]"
     }
-    else {
-        $index = 1
-        foreach ($distro in $Distros) {
-            Format-DistroListEntry -Index $index -Distro $distro
-            $index++
+
+    $index = 0
+    $tableData = foreach ($distro in $Distros) {
+        $index++
+        $stateMarkup = if ($distro.State -eq "Running") { "[green]Running[/]" } else { "[grey]Stopped[/]" }
+        $defaultMark = if ($distro.IsDefault) { "[green]*[/]" } else { "" }
+        [PSCustomObject]@{
+            '#'       = $index
+            'Name'    = $distro.Name
+            'State'   = $stateMarkup
+            'Version' = "WSL$($distro.Version)"
+            'Default' = $defaultMark
         }
     }
-    Write-Host ""
+
+    $tableData | Format-SpectreTable -Border Rounded -Color Cyan -AllowMarkup
 }
 
 function Select-WslDistro {
@@ -114,14 +91,7 @@ function Select-WslDistro {
     }
 
     if ($showTable) {
-        Write-Host ""
-        Write-Host "Available distributions:" -ForegroundColor Cyan
-        $index = 1
-        foreach ($distro in $Distros) {
-            Format-DistroListEntry -Index $index -Distro $distro
-            $index++
-        }
-        Write-Host ""
+        Show-WslDistroTable -Distros $Distros
     }
 
     if ([string]::IsNullOrWhiteSpace($Selection)) {
@@ -700,7 +670,7 @@ function Invoke-WslCommand {
 
     switch ($Command) {
         "list" {
-            Show-WslDistroList -Distros $Distros
+            Show-WslDistroTable -Distros $Distros
         }
         "install" {
             Invoke-CreateDistro -Name $Name

--- a/lib/wsl/commands.ps1
+++ b/lib/wsl/commands.ps1
@@ -25,12 +25,27 @@ function Show-WslDistroTable {
     .SYNOPSIS
         Displays installed WSL distributions as a formatted Spectre table.
 
+    .DESCRIPTION
+        Renders a Spectre.Console table showing all installed WSL distributions with
+        their index, name, state (Running/Stopped), WSL version, and default marker.
+        Returns a Spectre renderable object for use in layouts or panels.
+
     .PARAMETER Distros
         Optional pre-fetched list of distributions. If not provided, fetches from WSL.
 
     .OUTPUTS
         A Spectre renderable table object, or a markup string when no distributions are found.
+
+    .EXAMPLE
+        Show-WslDistroTable
+        # Fetches distributions from WSL and displays them as a formatted table.
+
+    .EXAMPLE
+        $distros = Get-WslDistroList -Detailed
+        Show-WslDistroTable -Distros $distros
+        # Displays a pre-fetched list of distributions as a formatted table.
     #>
+    [CmdletBinding()]
     param(
         [PSCustomObject[]]$Distros = $null
     )
@@ -91,7 +106,7 @@ function Select-WslDistro {
     }
 
     if ($showTable) {
-        Show-WslDistroTable -Distros $Distros
+        Show-WslDistroTable -Distros $Distros | Out-Host
     }
 
     if ([string]::IsNullOrWhiteSpace($Selection)) {

--- a/lib/wsl/manager.Tests.ps1
+++ b/lib/wsl/manager.Tests.ps1
@@ -3,10 +3,7 @@
     Pester tests for manager.ps1
 #>
 
-# Stub parameters are required for Pester ParameterFilter matching but are not used in the stub body
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Stub function parameters are required for Pester ParameterFilter matching')]
-# Stub functions mirror PwshSpectreConsole cmdlet signatures which use plural nouns and state-changing verbs
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Stub functions mirror PwshSpectreConsole cmdlet names')]
+# Stub functions mirror PwshSpectreConsole cmdlet names which use state-changing verbs
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Stub functions mirror PwshSpectreConsole cmdlet names')]
 param()
 
@@ -18,13 +15,21 @@ BeforeAll {
     # without triggering module auto-import (which causes UTF-8 encoding warnings).
     # manager.ps1 skips Import-Module in test environments, so these stubs provide
     # the command names that Pester needs for Mock/Should -Invoke.
-    function Read-SpectreSelection { param($Message, $Choices, $PageSize, [switch]$EnableSearch) }
-    function Format-SpectrePanel { param($Header, $Border, [switch]$Expand) process { } }
-    function Format-SpectreTable { param($Border, $Color, [switch]$AllowMarkup) process { } }
-    function Format-SpectreColumns { process { } }
-    function Format-SpectreRows { process { } }
-    function Write-SpectreFigletText { param($Text, $Alignment, $Color, [switch]$PassThru) }
-    function New-SpectreLayout { param($Columns, $Rows) }
+    # Note: Format-SpectreColumns and Format-SpectreRows use plural nouns to match
+    # the real PwshSpectreConsole cmdlet names; renaming is not possible.
+    function Read-SpectreSelection { param($Message, $Choices, $PageSize, [switch]$EnableSearch) $null = $Message, $Choices, $PageSize, $EnableSearch }
+    function Format-SpectrePanel { param($Header, $Border, [switch]$Expand) process { $null = $Header, $Border, $Expand; $_ } }
+    function Format-SpectreTable { param($Border, $Color, [switch]$AllowMarkup) process { $null = $Border, $Color, $AllowMarkup; $_ } }
+    function Format-SpectreColumns {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Must match PwshSpectreConsole cmdlet name')]
+        param() process { $_ }
+    }
+    function Format-SpectreRows {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Must match PwshSpectreConsole cmdlet name')]
+        param() process { $_ }
+    }
+    function Write-SpectreFigletText { param($Text, $Alignment, $Color, [switch]$PassThru) $null = $Text, $Alignment, $Color, $PassThru }
+    function New-SpectreLayout { param($Columns, $Rows) $null = $Columns, $Rows }
 
     . "$PSScriptRoot\commands.ps1"
     . "$PSScriptRoot\manager.ps1"

--- a/lib/wsl/manager.Tests.ps1
+++ b/lib/wsl/manager.Tests.ps1
@@ -5,6 +5,9 @@
 
 # Stub parameters are required for Pester ParameterFilter matching but are not used in the stub body
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Stub function parameters are required for Pester ParameterFilter matching')]
+# Stub functions mirror PwshSpectreConsole cmdlet signatures which use plural nouns and state-changing verbs
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Stub functions mirror PwshSpectreConsole cmdlet names')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Stub functions mirror PwshSpectreConsole cmdlet names')]
 param()
 
 BeforeAll {
@@ -316,13 +319,13 @@ Describe "Invoke-WslManager" {
                 )
             } -ParameterFilter { $Detailed }
             Mock Write-Host {}
+            Mock Show-WslDistroTable {}
             Mock Read-Host { "Debian" }
             Mock Remove-WslDistro {}
 
             Invoke-WslManager -Command "remove"
 
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Debian*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Ubuntu*" }
+            Should -Invoke Show-WslDistroTable -Times 1
         }
 
         It "Should support selection by number" {
@@ -580,15 +583,14 @@ Describe "Invoke-WslManager" {
                 )
             } -ParameterFilter { $Detailed }
             Mock Write-Host {}
+            Mock Show-WslDistroTable {}
             Mock Read-Host { "1" } -ParameterFilter { $Prompt -like "*number or name*" }
             Mock Read-Host { "MyProject" } -ParameterFilter { $Prompt -like "*target*" }
             Mock Copy-WslDistro {}
 
             Invoke-WslManager -Command "clone"
 
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Debian*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Ubuntu*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Alpine*" }
+            Should -Invoke Show-WslDistroTable -Times 1
         }
 
         It "Should support selection by number for source" {
@@ -715,13 +717,13 @@ Describe "Invoke-WslManager" {
                 )
             } -ParameterFilter { $Detailed }
             Mock Write-Host {}
+            Mock Show-WslDistroTable {}
             Mock Read-Host { "Debian" }
             Mock Update-WslDistro {}
 
             Invoke-WslManager -Command "update"
 
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Debian*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Ubuntu*" }
+            Should -Invoke Show-WslDistroTable -Times 1
         }
 
         It "Should support selection by number" {
@@ -1540,13 +1542,13 @@ Describe "Invoke-WslManager" {
                 )
             } -ParameterFilter { $Detailed }
             Mock Write-Host {}
+            Mock Show-WslDistroTable {}
             Mock Read-Host { "Debian" }
             Mock Stop-WslDistro {}
 
             Invoke-WslManager -Command "terminate"
 
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Debian*" }
-            Should -Invoke Write-Host -ParameterFilter { $Object -like "*Ubuntu*" }
+            Should -Invoke Show-WslDistroTable -Times 1
         }
 
         It "Should call Stop-WslDistro when Name is provided" {

--- a/lib/wsl/manager.Tests.ps1
+++ b/lib/wsl/manager.Tests.ps1
@@ -16,7 +16,12 @@ BeforeAll {
     # manager.ps1 skips Import-Module in test environments, so these stubs provide
     # the command names that Pester needs for Mock/Should -Invoke.
     function Read-SpectreSelection { param($Message, $Choices, $PageSize, [switch]$EnableSearch) }
-    function Format-SpectrePanel { param($Border) process { } }
+    function Format-SpectrePanel { param($Header, $Border, [switch]$Expand) process { } }
+    function Format-SpectreTable { param($Border, $Color, [switch]$AllowMarkup) process { } }
+    function Format-SpectreColumns { process { } }
+    function Format-SpectreRows { process { } }
+    function Write-SpectreFigletText { param($Text, $Alignment, $Color, [switch]$PassThru) }
+    function New-SpectreLayout { param($Columns, $Rows) }
 
     . "$PSScriptRoot\commands.ps1"
     . "$PSScriptRoot\manager.ps1"
@@ -24,6 +29,34 @@ BeforeAll {
 
 AfterAll {
     Stop-SutIsolation
+}
+
+Describe "Get-WslBrandingPanel" {
+    BeforeEach {
+        Mock Write-SpectreFigletText { "mocked-figlet" }
+        Mock Format-SpectreColumns { "mocked-columns" }
+        Mock Format-SpectreRows { "mocked-rows" }
+    }
+
+    It "Should call Write-SpectreFigletText with WSL Manager text" {
+        Get-WslBrandingPanel
+
+        Should -Invoke Write-SpectreFigletText -ParameterFilter {
+            $Text -eq "WSL Manager" -and $Alignment -eq "Center" -and $PassThru -eq $true
+        }
+    }
+
+    It "Should compose logo and tux side by side with Format-SpectreColumns" {
+        Get-WslBrandingPanel
+
+        Should -Invoke Format-SpectreColumns -Times 1
+    }
+
+    It "Should compose all elements vertically with Format-SpectreRows" {
+        Get-WslBrandingPanel
+
+        Should -Invoke Format-SpectreRows -Times 1
+    }
 }
 
 Describe "Show-WslMenu" {
@@ -85,12 +118,14 @@ Describe "Start-InteractiveMode" {
             Mock Clear-Host {}
             Mock Read-Host {}
             Mock Format-SpectrePanel {}
+            Mock New-SpectreLayout {}
+            Mock Show-WslDistroTable { "mocked-table" }
+            Mock Get-WslBrandingPanel { "mocked-branding" }
         }
 
         It "Should exit when user selects Quit" {
             Mock Test-RunningInCIorTestEnvironment { $false }
             Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             Mock Show-WslMenu { "quit" }
 
             $result = Start-InteractiveMode
@@ -101,7 +136,6 @@ Describe "Start-InteractiveMode" {
         It "Should exit when user cancels with Ctrl+C" {
             Mock Test-RunningInCIorTestEnvironment { $false }
             Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             Mock Show-WslMenu { $null }
 
             $result = Start-InteractiveMode
@@ -109,12 +143,22 @@ Describe "Start-InteractiveMode" {
             $result | Should -Be $true
         }
 
+        It "Should build two-column layout with New-SpectreLayout" {
+            Mock Test-RunningInCIorTestEnvironment { $false }
+            Mock Get-WslDistroList { @() } -ParameterFilter { $Detailed }
+            Mock Show-WslMenu { "quit" }
+
+            Start-InteractiveMode
+
+            Should -Invoke New-SpectreLayout -Times 1
+            Should -Invoke Format-SpectrePanel -Times 2  # left and right panels
+        }
+
         It "Should dispatch to Invoke-WslCommand with 'setup-podman'" {
             Mock Test-RunningInCIorTestEnvironment { $false }
             Mock Get-WslDistroList {
                 @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
             } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             $script:callCount = 0
             Mock Show-WslMenu {
                 $script:callCount++
@@ -133,7 +177,6 @@ Describe "Start-InteractiveMode" {
             Mock Get-WslDistroList {
                 @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
             } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             $script:callCount = 0
             Mock Show-WslMenu {
                 $script:callCount++
@@ -152,7 +195,6 @@ Describe "Start-InteractiveMode" {
             Mock Get-WslDistroList {
                 @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
             } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             $script:callCount = 0
             Mock Show-WslMenu {
                 $script:callCount++
@@ -172,7 +214,6 @@ Describe "Start-InteractiveMode" {
                 [PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true }
             )
             Mock Get-WslDistroList { $mockDistros } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             $script:callCount = 0
             Mock Show-WslMenu {
                 $script:callCount++
@@ -190,7 +231,6 @@ Describe "Start-InteractiveMode" {
         It "Should handle Get-WslDistroList errors gracefully" {
             Mock Test-RunningInCIorTestEnvironment { $false }
             Mock Get-WslDistroList { throw "WSL service not available" } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             Mock Write-ErrorMsg {}
             Mock Show-WslMenu { "quit" }
 
@@ -204,7 +244,6 @@ Describe "Start-InteractiveMode" {
             Mock Get-WslDistroList {
                 @([PSCustomObject]@{ Name = "Debian"; State = "Running"; Version = 2; IsDefault = $true })
             } -ParameterFilter { $Detailed }
-            Mock Write-Host {}
             Mock Write-ErrorMsg {}
             Mock Invoke-WslCommand { throw "Command failed" }
             $script:callCount = 0
@@ -241,12 +280,12 @@ Describe "Invoke-WslManager" {
     }
 
     Context "When called with 'list' argument" {
-        It "Should call Show-WslDistroList" {
-            Mock Show-WslDistroList {}
+        It "Should call Show-WslDistroTable" {
+            Mock Show-WslDistroTable {}
 
             Invoke-WslManager -Command "list"
 
-            Should -Invoke Show-WslDistroList -Times 1
+            Should -Invoke Show-WslDistroTable -Times 1
         }
     }
 

--- a/lib/wsl/manager.docker.Integration.Tests.ps1
+++ b/lib/wsl/manager.docker.Integration.Tests.ps1
@@ -29,6 +29,9 @@
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Integration tests use Write-Host for user feedback during manual test runs.')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseBOMForUnicodeEncodedFile', '', Justification = 'File is UTF-8 without BOM, which is standard for cross-platform compatibility.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Stub function parameters mirror PwshSpectreConsole cmdlet signatures')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Stub functions mirror PwshSpectreConsole cmdlet names')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Stub functions mirror PwshSpectreConsole cmdlet names')]
 param()
 
 Describe "WSL Manager Integration Tests" -Tag "Integration" {
@@ -48,6 +51,31 @@ Describe "WSL Manager Integration Tests" -Tag "Integration" {
         }
 
         Write-Host "==> Preparing test environment ..." -ForegroundColor Cyan
+
+        # Define stub functions for PwshSpectreConsole commands that are not
+        # available in CI.  These must be defined BEFORE dot-sourcing the
+        # library files so the commands resolve at call-time.
+        if (-not (Get-Command Format-SpectreTable -ErrorAction SilentlyContinue)) {
+            function Format-SpectreTable { param($Border, $Color, [switch]$AllowMarkup) process { $_ } }
+        }
+        if (-not (Get-Command Format-SpectrePanel -ErrorAction SilentlyContinue)) {
+            function Format-SpectrePanel { param($Header, $Border, [switch]$Expand) process { $_ } }
+        }
+        if (-not (Get-Command Format-SpectreColumns -ErrorAction SilentlyContinue)) {
+            function Format-SpectreColumns { process { $_ } }
+        }
+        if (-not (Get-Command Format-SpectreRows -ErrorAction SilentlyContinue)) {
+            function Format-SpectreRows { process { $_ } }
+        }
+        if (-not (Get-Command Write-SpectreFigletText -ErrorAction SilentlyContinue)) {
+            function Write-SpectreFigletText { param($Text, $Alignment, $Color, [switch]$PassThru) }
+        }
+        if (-not (Get-Command New-SpectreLayout -ErrorAction SilentlyContinue)) {
+            function New-SpectreLayout { param($Columns, $Rows) }
+        }
+        if (-not (Get-Command Read-SpectreSelection -ErrorAction SilentlyContinue)) {
+            function Read-SpectreSelection { param($Message, $Choices, $PageSize, [switch]$EnableSearch) }
+        }
 
         # Load the library functions
         . (Join-Path $PSScriptRoot "commands.ps1")

--- a/lib/wsl/manager.docker.Integration.Tests.ps1
+++ b/lib/wsl/manager.docker.Integration.Tests.ps1
@@ -29,8 +29,6 @@
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Integration tests use Write-Host for user feedback during manual test runs.')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseBOMForUnicodeEncodedFile', '', Justification = 'File is UTF-8 without BOM, which is standard for cross-platform compatibility.')]
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Stub function parameters mirror PwshSpectreConsole cmdlet signatures')]
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Stub functions mirror PwshSpectreConsole cmdlet names')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Stub functions mirror PwshSpectreConsole cmdlet names')]
 param()
 
@@ -55,26 +53,34 @@ Describe "WSL Manager Integration Tests" -Tag "Integration" {
         # Define stub functions for PwshSpectreConsole commands that are not
         # available in CI.  These must be defined BEFORE dot-sourcing the
         # library files so the commands resolve at call-time.
+        # Note: Format-SpectreColumns and Format-SpectreRows use plural nouns to match
+        # the real PwshSpectreConsole cmdlet names; renaming is not possible.
         if (-not (Get-Command Format-SpectreTable -ErrorAction SilentlyContinue)) {
-            function Format-SpectreTable { param($Border, $Color, [switch]$AllowMarkup) process { $_ } }
+            function Format-SpectreTable { param($Border, $Color, [switch]$AllowMarkup) process { $null = $Border, $Color, $AllowMarkup; $_ } }
         }
         if (-not (Get-Command Format-SpectrePanel -ErrorAction SilentlyContinue)) {
-            function Format-SpectrePanel { param($Header, $Border, [switch]$Expand) process { $_ } }
+            function Format-SpectrePanel { param($Header, $Border, [switch]$Expand) process { $null = $Header, $Border, $Expand; $_ } }
         }
         if (-not (Get-Command Format-SpectreColumns -ErrorAction SilentlyContinue)) {
-            function Format-SpectreColumns { process { $_ } }
+            function Format-SpectreColumns {
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Must match PwshSpectreConsole cmdlet name')]
+                param() process { $_ }
+            }
         }
         if (-not (Get-Command Format-SpectreRows -ErrorAction SilentlyContinue)) {
-            function Format-SpectreRows { process { $_ } }
+            function Format-SpectreRows {
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Must match PwshSpectreConsole cmdlet name')]
+                param() process { $_ }
+            }
         }
         if (-not (Get-Command Write-SpectreFigletText -ErrorAction SilentlyContinue)) {
-            function Write-SpectreFigletText { param($Text, $Alignment, $Color, [switch]$PassThru) }
+            function Write-SpectreFigletText { param($Text, $Alignment, $Color, [switch]$PassThru) $null = $Text, $Alignment, $Color, $PassThru }
         }
         if (-not (Get-Command New-SpectreLayout -ErrorAction SilentlyContinue)) {
-            function New-SpectreLayout { param($Columns, $Rows) }
+            function New-SpectreLayout { param($Columns, $Rows) $null = $Columns, $Rows }
         }
         if (-not (Get-Command Read-SpectreSelection -ErrorAction SilentlyContinue)) {
-            function Read-SpectreSelection { param($Message, $Choices, $PageSize, [switch]$EnableSearch) }
+            function Read-SpectreSelection { param($Message, $Choices, $PageSize, [switch]$EnableSearch) $null = $Message, $Choices, $PageSize, $EnableSearch }
         }
 
         # Load the library functions

--- a/lib/wsl/manager.docker.Integration.Tests.ps1
+++ b/lib/wsl/manager.docker.Integration.Tests.ps1
@@ -231,7 +231,7 @@ Describe "WSL Manager Integration Tests" -Tag "Integration" {
             Write-Host "`n==> TEST: Listing distributions ..." -ForegroundColor Magenta
 
             # Call the script to display the list (for visual verification)
-            Show-WslDistroList
+            Show-WslDistroTable
 
             Write-Host "`n==> Captured Output:" -ForegroundColor Cyan
 

--- a/lib/wsl/manager.ps1
+++ b/lib/wsl/manager.ps1
@@ -67,8 +67,18 @@ function Get-WslBrandingPanel {
     <#
     .SYNOPSIS
         Creates the branding content with shortcuts logo, Tux ASCII art, FigletText, and slogan.
+
+    .DESCRIPTION
+        Composes a Spectre.Console renderable combining the shortcuts 4-quadrant colored logo,
+        Tux ASCII art, a FigletText "WSL Manager" title, and a slogan. Used as the right panel
+        in the TUI two-column layout.
+
     .OUTPUTS
         A Spectre renderable for the right panel of the TUI layout.
+
+    .EXAMPLE
+        Get-WslBrandingPanel | Format-SpectrePanel -Header "Branding" -Border Rounded
+        # Creates the branding panel and wraps it in a Spectre panel with a header.
     #>
     [CmdletBinding()]
     param()

--- a/lib/wsl/manager.ps1
+++ b/lib/wsl/manager.ps1
@@ -63,6 +63,48 @@ if (-not (Test-RunningInCIorTestEnvironment)) {
     Import-Module PwshSpectreConsole -ErrorAction Stop
 }
 
+function Get-WslBrandingPanel {
+    <#
+    .SYNOPSIS
+        Creates the branding content with shortcuts logo, Tux ASCII art, FigletText, and slogan.
+    .OUTPUTS
+        A Spectre renderable for the right panel of the TUI layout.
+    #>
+    [CmdletBinding()]
+    param()
+
+    # Shortcuts logo - 4-quadrant colored badge representing the hexagonal logo
+    $logoArt = @(
+        "  [dodgerblue2]▄▄▄▄[/][orange1]▄▄▄▄[/]"
+        " [dodgerblue2]██████[/][orange1]██████[/]"
+        " [dodgerblue2]██████[/][orange1]██████[/]"
+        " [green]██████[/][deeppink3]██████[/]"
+        " [green]██████[/][deeppink3]██████[/]"
+        "  [green]▀▀▀▀[/][deeppink3]▀▀▀▀[/]"
+    ) -join "`n"
+
+    # Tux (Linux penguin) ASCII art
+    $tuxArt = @(
+        "    .--."
+        "   |o_o |"
+        "   |:_/ |"
+        "  //   \ \"
+        " (|     | )"
+        "/'\_   _/``\"
+        "\___)=(___/"
+    ) -join "`n"
+
+    # FigletText title
+    $figlet = Write-SpectreFigletText -Text "WSL Manager" -Alignment Center -Color "DeepSkyBlue1" -PassThru
+
+    # Slogan
+    $slogan = "[italic grey]Your DevOps environment at ease![/]"
+
+    # Compose: logo and tux side by side, then figlet and slogan below
+    $artRow = @($logoArt, $tuxArt) | Format-SpectreColumns
+    @($artRow, $figlet, $slogan) | Format-SpectreRows
+}
+
 function Show-WslMenu {
     <#
     .SYNOPSIS
@@ -118,20 +160,27 @@ function Start-InteractiveMode {
     $continue = $true
     while ($continue) {
         Clear-Host
-        "[cyan]WSL Manager[/]" | Format-SpectrePanel -Border Rounded
 
-        # Fetch current distributions once per loop iteration and display the table.
+        # Fetch current distributions once per loop iteration.
         # The fetched list is passed to action functions so they use consistent numbering
         # and do not re-fetch or reprint the table.
         $menuDistros = $null
         try {
             $menuDistros = @(Get-WslDistroList -Detailed)
-            Show-WslDistroList -Distros $menuDistros
         }
         catch {
             Write-ErrorMsg "$_"
-            Write-Host ""
         }
+
+        # Build two-column layout: distro table (left), branding (right)
+        $distroContent = if ($null -ne $menuDistros) {
+            Show-WslDistroTable -Distros $menuDistros
+        } else {
+            "[yellow]Could not load distributions.[/]"
+        }
+        $leftPanel = $distroContent | Format-SpectrePanel -Header "Distributions" -Border Rounded -Expand
+        $rightPanel = Get-WslBrandingPanel | Format-SpectrePanel -Border Rounded -Expand
+        New-SpectreLayout -Columns @($leftPanel, $rightPanel)
 
         $command = Show-WslMenu
 


### PR DESCRIPTION
Replace Format-DistroListEntry and Show-WslDistroList with Show-WslDistroTable using Format-SpectreTable. Add Get-WslBrandingPanel with shortcuts logo, Tux ASCII art, FigletText "WSL Manager", and slogan. Update Start-InteractiveMode to use New-SpectreLayout two-column layout.

Closes #66

Generated with [Claude Code](https://claude.ai/code)