### PR TITLE
ci: repoint shared-skills plugin + refresh model aliases (SC-038, SC-039)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,9 +64,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--model ${{ steps.parse-model.outputs.model }}'
           plugin_marketplaces: |
-            https://github.com/xxthunder/xxthunder-dev-skills.git
+            https://github.com/xxthunder/xxthunder-agentic-skills.git
           plugins: |
-            xxthunder-dev-skills@xxthunder-skills
+            xxthunder-dev-skills@xxthunder-agentic-skills
 
           additional_permissions: |
             actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,13 +43,21 @@ jobs:
           ALIAS_LOWER=$(echo "$ALIAS" | tr '[:upper:]' '[:lower:]')
 
           case "$ALIAS_LOWER" in
-            opus|opus-4-6)
+            opus|opus-4-7)
+              echo "model=claude-opus-4-7" >> "$GITHUB_OUTPUT"
+              echo "Resolved model alias '$ALIAS' -> claude-opus-4-7"
+              ;;
+            opus-4-6)
               echo "model=claude-opus-4-6" >> "$GITHUB_OUTPUT"
               echo "Resolved model alias '$ALIAS' -> claude-opus-4-6"
               ;;
             sonnet|sonnet-4-6)
               echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"
               echo "Resolved model alias '$ALIAS' -> claude-sonnet-4-6"
+              ;;
+            haiku|haiku-4-5)
+              echo "model=claude-haiku-4-5-20251001" >> "$GITHUB_OUTPUT"
+              echo "Resolved model alias '$ALIAS' -> claude-haiku-4-5-20251001"
               ;;
             *)
               echo "model=claude-sonnet-4-6" >> "$GITHUB_OUTPUT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -655,7 +655,7 @@ Provide specific feedback with `file:line` references.
 
 ### Shared Skills Plugin
 
-This project uses the [xxthunder/xxthunder-dev-skills](https://github.com/xxthunder/xxthunder-dev-skills) plugin for shared skills (refinement, commit-helper, tdd-workflow, retrospective). The plugin is loaded automatically:
+This project uses the [xxthunder/xxthunder-agentic-skills](https://github.com/xxthunder/xxthunder-agentic-skills) plugin for shared skills (refinement, commit-helper, tdd-workflow, retrospective). The plugin is loaded automatically:
 
 - **Locally**: installed to `~/.claude/plugins/` via `claude plugins add`
 - **GitHub Actions**: configured via the `plugins` input in `.github/workflows/claude.yml`

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -35,6 +35,7 @@
 
 ### Done
 
+- [SC-039 — Refresh @claude model aliases to current 4.x family](sc-039.md)
 - [SC-038 — Repoint claude.yml shared-skills plugin to renamed xxthunder-agentic-skills repo](sc-038.md)
 - [SC-017 — Auto-terminate distros instead of prompting the user](sc-017.md)
 - [SC-036a — Add setup-proxy mode/auth prompts and mode marker](sc-036a.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -35,6 +35,7 @@
 
 ### Done
 
+- [SC-038 — Repoint claude.yml shared-skills plugin to renamed xxthunder-agentic-skills repo](sc-038.md)
 - [SC-017 — Auto-terminate distros instead of prompting the user](sc-017.md)
 - [SC-036a — Add setup-proxy mode/auth prompts and mode marker](sc-036a.md)
 - [SC-035 — Add sync-ssh-config command for Windows DevPod access](sc-035.md)

--- a/docs/backlog/sc-038.md
+++ b/docs/backlog/sc-038.md
@@ -1,0 +1,33 @@
+[← Back to Backlog](README.md)
+
+# [SC-038] ✅ DONE - Repoint claude.yml shared-skills plugin to renamed xxthunder-agentic-skills repo
+
+**Status**: Done (2026-05-24)
+**Priority**: High
+**Component**: `.github/workflows/claude.yml`, `AGENTS.md`
+
+**Summary**:
+As a contributor using `@claude` on GitHub, I want the shared-skills plugin reference repointed to the renamed `xxthunder-agentic-skills` repo, so that the Claude GitHub Action resolves the marketplace and loads the shared skills instead of failing on a 404.
+
+**Description**:
+SC-027 wired the Claude GitHub Action to load shared skills from a plugin marketplace. That marketplace repo has since been renamed from `xxthunder/xxthunder-dev-skills` to `xxthunder/xxthunder-agentic-skills`, and the marketplace name in its `marketplace.json` changed from `xxthunder-skills` to `xxthunder-agentic-skills`. The plugin name is unchanged (`xxthunder-dev-skills`). `claude.yml` still pointed at the old URL and old marketplace name, so the action could no longer resolve the marketplace and `@claude` runs lost the shared skills.
+
+Changes applied (verified against the renamed repo, default branch `develop`):
+- `claude.yml:67` marketplace URL → `https://github.com/xxthunder/xxthunder-agentic-skills.git`
+- `claude.yml:69` plugin pin → `xxthunder-dev-skills@xxthunder-agentic-skills`
+- `AGENTS.md:658` doc link → `[xxthunder/xxthunder-agentic-skills](https://github.com/xxthunder/xxthunder-agentic-skills)`
+
+Out of scope:
+- `AGENTS.md:539` ("from the `xxthunder-dev-skills` plugin") — plugin name unchanged, stays correct.
+- Historical backlog entries (`sc-027.md`, `chore-001.md`) — kept as historical record.
+
+**Acceptance Criteria**:
+- [x] `claude.yml` marketplace URL points to `xxthunder-agentic-skills.git`
+- [x] `claude.yml` plugin pin is `xxthunder-dev-skills@xxthunder-agentic-skills`
+- [x] `AGENTS.md` shared-skills link points to the renamed repo
+- [x] Plugin pin matches the live marketplace manifest — verified against the renamed repo (marketplace `xxthunder-agentic-skills`, plugin `xxthunder-dev-skills` v1.3.0)
+- [x] No active references to the old repo URL remain outside historical backlog entries
+
+**Note**: A live `@claude` trigger on a GitHub issue/PR is the recommended real-world smoke test to confirm the action loads a shared skill (e.g. commit-helper); it cannot be exercised from a local session.
+
+[← Back to Backlog](README.md)

--- a/docs/backlog/sc-039.md
+++ b/docs/backlog/sc-039.md
@@ -1,0 +1,30 @@
+[← Back to Backlog](README.md)
+
+# [SC-039] ✅ DONE - Refresh @claude model aliases to current 4.x family
+
+**Status**: Done (2026-05-24)
+**Priority**: Low
+**Component**: `.github/workflows/claude.yml`
+
+**Summary**:
+As a contributor using `@claude` on GitHub, I want the model aliases to map to the current Claude 4.x family, so that `@claude opus` selects the latest Opus (4.7) and a Haiku option is available.
+
+**Description**:
+The `parse-model` step in `claude.yml` mapped `opus` to `claude-opus-4-6`, which is now one release behind the latest Opus (4.7), and offered no Haiku alias. This refreshes the alias table:
+
+- `opus` / `opus-4-7` → `claude-opus-4-7` (latest Opus)
+- `opus-4-6` → `claude-opus-4-6` (explicit legacy pin retained)
+- `sonnet` / `sonnet-4-6` → `claude-sonnet-4-6`
+- `haiku` / `haiku-4-5` → `claude-haiku-4-5-20251001`
+- default (unknown alias) → `claude-sonnet-4-6` (unchanged)
+
+The default is deliberately left as `claude-sonnet-4-6` to preserve existing cost-conscious behavior.
+
+**Acceptance Criteria**:
+- [x] `opus` and `opus-4-7` resolve to `claude-opus-4-7`
+- [x] Explicit `opus-4-6` still resolves to `claude-opus-4-6`
+- [x] `haiku` / `haiku-4-5` resolves to `claude-haiku-4-5-20251001`
+- [x] `sonnet` / `sonnet-4-6` resolves to `claude-sonnet-4-6`
+- [x] Default for an unknown alias remains `claude-sonnet-4-6`
+
+[← Back to Backlog](README.md)


### PR DESCRIPTION
## Summary

Two related `claude.yml` fixes bundled in one PR:

1. **SC-038** — The shared-skills marketplace repo was renamed from `xxthunder/xxthunder-dev-skills` to `xxthunder/xxthunder-agentic-skills`, and its marketplace name in `marketplace.json` changed from `xxthunder-skills` to `xxthunder-agentic-skills`. `claude.yml` still referenced the old URL and marketplace name, so the Claude GitHub Action could no longer resolve the marketplace — `@claude` runs lost the shared skills. The **plugin name** (`xxthunder-dev-skills`) is unchanged.
2. **SC-039** — The model-alias table was stale: `opus` mapped to `claude-opus-4-6` (one release behind 4.7) and there was no Haiku option. Refreshed to the current 4.x family.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/claude.yml` | marketplace URL → `xxthunder-agentic-skills.git`; plugin pin → `xxthunder-dev-skills@xxthunder-agentic-skills`; refreshed model aliases |
| `AGENTS.md` | shared-skills plugin link → renamed repo |
| `docs/backlog/sc-038.md`, `sc-039.md` | new backlog items (closed) |
| `docs/backlog/README.md` | SC-038 + SC-039 added to Done |

### Model aliases (SC-039)

| Alias | Resolves to |
|-------|-------------|
| `opus`, `opus-4-7` | `claude-opus-4-7` (latest Opus) |
| `opus-4-6` | `claude-opus-4-6` (legacy pin retained) |
| `sonnet`, `sonnet-4-6` | `claude-sonnet-4-6` |
| `haiku`, `haiku-4-5` | `claude-haiku-4-5-20251001` |
| _(unknown / default)_ | `claude-sonnet-4-6` (unchanged) |

## Verification

- `plugins` / `plugin_marketplaces` confirmed as valid `claude-code-action@v1` inputs; format `plugin@marketplace` matches the action's documented example.
- Marketplace name (`xxthunder-agentic-skills`) and plugin (`xxthunder-dev-skills` v1.3.0) verified against the live `marketplace.json` on the renamed repo (default branch `develop`). Repo is public — no auth needed.
- Grep confirms no active references to the old repo URL / marketplace name remain (historical backlog entries left as record).

## Remaining smoke test

A live `@claude` trigger on this PR is the recommended real-world confirmation that the action loads a shared skill (e.g. commit-helper) and resolves the new aliases.

Closes SC-038. Closes SC-039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)