### PR TITLE
feat(proxy): Windows-side px authenticating proxy tool (SC-040)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ It provides both a TUI (menu-driven interface) and CLI commands to:
 ## More Features
 
 - **[Flow Launcher](docs/runbooks/flow-launcher-setup.md)**: A modern, actively maintained alternative launcher to Keypirinha with plugin support and auto-reload
+- **[px Proxy](docs/runbooks/px-proxy.md)**: A Windows-side local authenticating proxy (px) that gives native CLI tools and WSL seamless SSPI/Kerberos auth through the corporate proxy, with no stored credentials
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ It provides both a TUI (menu-driven interface) and CLI commands to:
 
 ## More Features
 
-- **[Flow Launcher](docs/flow-launcher-setup.md)**: A modern, actively maintained alternative launcher to Keypirinha with plugin support and auto-reload
+- **[Flow Launcher](docs/runbooks/flow-launcher-setup.md)**: A modern, actively maintained alternative launcher to Keypirinha with plugin support and auto-reload
 
 ---
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -15,7 +15,6 @@
 - [SC-001 — Backlog refinement](sc-001.md)
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
 - [SC-036 — Add Negotiate (Kerberos) proxy auth mode to setup-proxy](sc-036.md)
-- [SC-040 — Add Windows-side px authenticating proxy tool](sc-040.md)
 
 ### Open
 
@@ -36,6 +35,7 @@
 
 ### Done
 
+- [SC-040 — Add Windows-side px authenticating proxy tool](sc-040.md)
 - [SC-041 — Move tool-specific documentation into docs/runbooks/](sc-041.md)
 - [SC-039 — Refresh @claude model aliases to current 4.x family](sc-039.md)
 - [SC-038 — Repoint claude.yml shared-skills plugin to renamed xxthunder-agentic-skills repo](sc-038.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -27,7 +27,6 @@
 - [SC-036c — Negotiate mode Phases 2–3: Kerberos + px activation](sc-036c.md)
 - [SC-036d — Negotiate mode Phase 4: switch targets to localhost and auto-start px](sc-036d.md)
 - [SC-036e — Mode-aware `--remove` teardown and Negotiate docs](sc-036e.md)
-- [SC-040 — Add Windows-side px authenticating proxy tool](sc-040.md)
 - [SC-020 — Import and export WSL distributions to/from files](sc-020.md)
 - [SC-023 — Per-file code coverage in testrunner.ps1](sc-023.md)
 - [SC-032 — Investigate split-pane TUI layout for WSL Manager](sc-032.md)
@@ -36,6 +35,7 @@
 
 ### Done
 
+- [SC-040 — Add Windows-side px authenticating proxy tool](sc-040.md)
 - [SC-041 — Move tool-specific documentation into docs/runbooks/](sc-041.md)
 - [SC-039 — Refresh @claude model aliases to current 4.x family](sc-039.md)
 - [SC-038 — Repoint claude.yml shared-skills plugin to renamed xxthunder-agentic-skills repo](sc-038.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -15,6 +15,7 @@
 - [SC-001 — Backlog refinement](sc-001.md)
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
 - [SC-036 — Add Negotiate (Kerberos) proxy auth mode to setup-proxy](sc-036.md)
+- [SC-040 — Add Windows-side px authenticating proxy tool](sc-040.md)
 
 ### Open
 
@@ -35,7 +36,6 @@
 
 ### Done
 
-- [SC-040 — Add Windows-side px authenticating proxy tool](sc-040.md)
 - [SC-041 — Move tool-specific documentation into docs/runbooks/](sc-041.md)
 - [SC-039 — Refresh @claude model aliases to current 4.x family](sc-039.md)
 - [SC-038 — Repoint claude.yml shared-skills plugin to renamed xxthunder-agentic-skills repo](sc-038.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -27,6 +27,7 @@
 - [SC-036c — Negotiate mode Phases 2–3: Kerberos + px activation](sc-036c.md)
 - [SC-036d — Negotiate mode Phase 4: switch targets to localhost and auto-start px](sc-036d.md)
 - [SC-036e — Mode-aware `--remove` teardown and Negotiate docs](sc-036e.md)
+- [SC-040 — Add Windows-side px authenticating proxy tool](sc-040.md)
 - [SC-020 — Import and export WSL distributions to/from files](sc-020.md)
 - [SC-023 — Per-file code coverage in testrunner.ps1](sc-023.md)
 - [SC-032 — Investigate split-pane TUI layout for WSL Manager](sc-032.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -36,6 +36,7 @@
 
 ### Done
 
+- [SC-041 — Move tool-specific documentation into docs/runbooks/](sc-041.md)
 - [SC-039 — Refresh @claude model aliases to current 4.x family](sc-039.md)
 - [SC-038 — Repoint claude.yml shared-skills plugin to renamed xxthunder-agentic-skills repo](sc-038.md)
 - [SC-017 — Auto-terminate distros instead of prompting the user](sc-017.md)

--- a/docs/backlog/sc-040.md
+++ b/docs/backlog/sc-040.md
@@ -2,7 +2,7 @@
 
 # [SC-040] Add Windows-side px authenticating proxy tool
 
-**Status**: Open
+**Status**: Done (2026-07-09)
 **Priority**: High
 **Component**: `tools/proxy/px-proxy.ps1` (new), `tools/proxy/px-proxy.bat` (new), `tools/proxy/px-proxy.Tests.ps1` (new), `tools/proxy/setProxy.ps1`, `docs/runbooks/px-proxy.md` (new), `README.md`, `docs/roadmap.md`
 **Related**: [SC-036](sc-036.md) (WSL-side Negotiate proxy, the sibling approach), [SC-007](sc-007.md) (setup-proxy Basic auth)
@@ -32,30 +32,31 @@ This tool is **separate from wsl-manager**. It is a Windows-host concern and liv
 - **TLS inspection / corporate CA is out of scope for v1**: the corporate root CA affects all TLS, not just px, and is environment-specific. Document the CA-trust prerequisite and the `curl --ssl-no-revoke` quirk (Schannel hard revocation check fails on the inspected cert when the revocation endpoint is unreachable) in troubleshooting; do not have this tool manage cert stores.
 
 **Acceptance Criteria**:
-- [ ] `tools/proxy/px-proxy.ps1` exists as a standalone script (`#Requires -Version 7.4`, `Set-StrictMode -Version Latest`, `Invoke-CommandLine` for external commands) with an action parameter supporting at least `install`, `start`, `stop`, `test`, `remove`
-- [ ] `tools/proxy/px-proxy.bat` wrapper exists (`pwsh -ExecutionPolicy Bypass -File %~dp0px-proxy.ps1 %*`) so the tool is launchable from Keypirinha
-- [ ] `install`: installs px via `scoop install px` (from the already-present `main` bucket) only when no px is detected (recognizes both a Scoop shim and an existing pipx px), and ensures the tool's px data directory exists; `install` does **not** resolve the proxy or write any px config (that is `start`'s job)
-- [ ] `start`: resolves the real upstream proxy fresh on every invocation by PAC evaluation (reusing `setProxy.ps1`'s `Get-ProxyFromPac`, which runs the PAC's `FindProxyForURL` via `GetSystemWebProxy().GetProxy()` and returns a `scheme://host:port` URL for the real upstream proxy, not the PAC-distribution host), parsing the bare `host:port` out of that URL's authority (scheme stripped)
-- [ ] `start`: falls back to `klist`-derived `HTTP/<host>` SPN discovery (and finally a manual host prompt) when PAC evaluation yields DIRECT or no proxy
-- [ ] `start`: (re)writes the px config every time from the freshly-resolved proxy (`server = <resolved host:port>`, `listen = 127.0.0.1`, `port = 3128`, `auth` empty for SSPI auto-discovery, `[settings] log = 1` so a log file is written on startup) into the px data directory, overwriting any previous config
-- [ ] `start`: always (re)starts px to guarantee it reflects the freshly-written config: stops any already-running px, then launches `pxw.exe` in the background (no console window) with its working directory set to the px data dir so the log lands there; the result is exactly one running px instance
-- [ ] `stop`: stops any running px cleanly (`px --quit`, exit 0 even if none running)
-- [ ] `test`: performs an HTTPS request through `http://127.0.0.1:3128` (via `Invoke-WebRequest` using the Windows cert store) and reports success/failure with a clear diagnostic distinguishing a 407 (auth) from a TLS/cert error; accounts for the Schannel hard-revocation quirk (the `curl --ssl-no-revoke` equivalent) so an unreachable revocation endpoint on the inspected cert is surfaced as a distinct, non-fatal diagnostic rather than a generic failure, and points the user at the px log on failure
-- [ ] `remove`: stops px, uninstalls it (only if this tool installed it via Scoop), and deletes the px config and its log file(s)
-- [ ] `setProxy.ps1` gains an option to target `http://127.0.0.1:3128` (px) instead of the corporate proxy directly, so native CLI tools inherit working auth; default behavior for existing callers is unchanged unless the option is selected
-- [ ] Pester unit tests (`px-proxy.Tests.ps1`) cover each action, mocking `scoop`, px invocations, and the PAC/klist discovery branches (success + failure paths)
-- [ ] `docs/runbooks/px-proxy.md` documents the tool: what it does, when to use it, the mirrored-networking requirement for WSL, where the px log file lives, and troubleshooting (corporate root-CA import, `curl --ssl-no-revoke`, reading the px log, checking `klist`, restarting px)
-- [ ] `README.md` (More Features) and `docs/roadmap.md` reference the new tool
-- [ ] All existing tests continue to pass
+- [x] `tools/proxy/px-proxy.ps1` exists as a standalone script (`#Requires -Version 7.4`, `Set-StrictMode -Version Latest`, `Invoke-CommandLine` for external commands) with an action parameter supporting at least `install`, `start`, `stop`, `test`, `remove`
+- [x] `tools/proxy/px-proxy.bat` wrapper exists (`pwsh -ExecutionPolicy Bypass -File %~dp0px-proxy.ps1 %*`) so the tool is launchable from Keypirinha
+- [x] `install`: installs px via `scoop install px` (from the already-present `main` bucket) only when no px is detected (recognizes both a Scoop shim and an existing pipx px), and ensures the tool's px data directory exists; `install` does **not** resolve the proxy or write any px config (that is `start`'s job)
+- [x] `start`: resolves the real upstream proxy fresh on every invocation by PAC evaluation (reusing `setProxy.ps1`'s `Get-ProxyFromPac`, which runs the PAC's `FindProxyForURL` via `GetSystemWebProxy().GetProxy()` and returns a `scheme://host:port` URL for the real upstream proxy, not the PAC-distribution host), parsing the bare `host:port` out of that URL's authority (scheme stripped)
+- [x] `start`: falls back to `klist`-derived `HTTP/<host>` SPN discovery (and finally a manual host prompt) when PAC evaluation yields DIRECT or no proxy
+- [x] `start`: (re)writes the px config every time from the freshly-resolved proxy (`server = <resolved host:port>`, `listen = 127.0.0.1`, `port = 3128`, `auth` empty for SSPI auto-discovery, `[settings] log = 3` so a unique log file is written to px's working directory on startup) into the px data directory, overwriting any previous config
+- [x] `start`: always (re)starts px to guarantee it reflects the freshly-written config: stops any already-running px, then launches `pxw.exe` in the background (no console window) with its working directory set to the px data dir so the log lands there; the result is exactly one px instance (px itself runs a monitor plus worker process; a repeated `start` does not accumulate duplicates)
+- [x] `stop`: stops any running px cleanly (`px --quit`, exit 0 even if none running)
+- [x] `test`: performs an HTTPS request through `http://127.0.0.1:3128` (via `Invoke-WebRequest` using the Windows cert store) and reports success/failure with a clear diagnostic distinguishing a 407 (auth) from a TLS/cert error; accounts for the Schannel hard-revocation quirk (the `curl --ssl-no-revoke` equivalent) so an unreachable revocation endpoint on the inspected cert is surfaced as a distinct, non-fatal diagnostic rather than a generic failure, and points the user at the px log on failure
+- [x] `remove`: stops px, uninstalls it (only if this tool installed it via Scoop), and deletes the px config and its log file(s)
+- [x] `setProxy.ps1` gains an option to target `http://127.0.0.1:3128` (px) instead of the corporate proxy directly, so native CLI tools inherit working auth; default behavior for existing callers is unchanged unless the option is selected
+- [x] `setProxy.ps1` auto-detects a running px (TCP probe on the px endpoint) and targets it automatically without requiring `-UsePx`; `-NoPx` forces the corporate-proxy path and `-UsePx` still forces px unconditionally
+- [x] Pester unit tests (`px-proxy.Tests.ps1`) cover each action, mocking `scoop`, px invocations, and the PAC/klist discovery branches (success + failure paths)
+- [x] `docs/runbooks/px-proxy.md` documents the tool: what it does, when to use it, the mirrored-networking requirement for WSL, where the px log file lives, and troubleshooting (corporate root-CA import, `curl --ssl-no-revoke`, reading the px log, checking `klist`, restarting px)
+- [x] `README.md` (More Features) and `docs/roadmap.md` reference the new tool
+- [x] All existing tests continue to pass
 
 **UAT Procedure** (run on a corporate Windows machine with the feature branch checked out):
 
 1. [ ] **Install**: run `px-proxy install`. Expect: px present (Scoop or detected pipx) and the px data directory created; no px config written yet (config is a `start`-time artifact).
-2. [ ] **Start**: run `px-proxy start`. Expect: the proxy resolved fresh, a px config (re)written with the PAC-resolved proxy host and `listen = 127.0.0.1`, `port = 3128`, `[settings] log = 1`; a single `pxw.exe` process running, no console window, listening on `127.0.0.1:3128`, and a `debug-<pid>.log` written in the px data dir.
+2. [ ] **Start**: run `px-proxy start`. Expect: the proxy resolved fresh, a px config (re)written with the PAC-resolved proxy host and `listen = 127.0.0.1`, `port = 3128`, `[settings] log = 3`; px running (a monitor plus worker `pxw.exe` process), no console window, listening on `127.0.0.1:3128`, and a `debug-*.log` written in the px data dir.
 3. [ ] **Test (Windows)**: run `px-proxy test`. Expect: HTTPS request through `127.0.0.1:3128` returns success; no password prompted.
 4. [ ] **Native CLI**: with `setProxy.ps1` targeting px, run `git ls-remote https://github.com/...` (or `curl --ssl-no-revoke -x http://127.0.0.1:3128 https://github.com`). Expect: succeeds via SSPI, no credentials entered.
 5. [ ] **From WSL**: in a distro, `curl -x http://127.0.0.1:3128 https://www.google.com`. Expect: HTTP 200 (mirrored networking + trusted corporate CA in the distro).
-6. [ ] **Restart on start**: run `px-proxy start` again. Expect: config regenerated, px restarted, still exactly one `pxw.exe` instance (no duplicates), reflecting the freshly-resolved proxy.
+6. [ ] **Restart on start**: run `px-proxy start` again. Expect: config regenerated, px restarted, no duplicate accumulation (still a single px monitor plus worker), reflecting the freshly-resolved proxy.
 7. [ ] **Stop**: run `px-proxy stop`. Expect: px no longer running; a subsequent `test` reports failure clearly.
 8. [ ] **Remove**: run `px-proxy remove`. Expect: px stopped, config and log file(s) deleted, px uninstalled only if this tool installed it.
 
@@ -69,9 +70,11 @@ This tool is **separate from wsl-manager**. It is a Windows-host concern and liv
   auth =
 
   [settings]
-  log = 1
+  log = 3
   ```
-- Logging: `[settings] log = 1` makes px write a `debug-<pid>.log` in its working directory. Start `pxw.exe` with its working directory set to the tool's px data dir (where the config lives) so the log lands in a stable, known location that `test` and troubleshooting can point at. `remove` deletes these log files.
+- Logging: px `log` levels are 1 = script (binary) dir, 2 = working dir, 3 = working dir with a unique filename. This tool uses `log = 3` and launches `pxw.exe` with its working directory set to the tool's px data dir, so a unique `debug-*.log` lands in a stable, known location that `test` and troubleshooting can point at. `remove` deletes these log files. (`log = 1` writes next to the px binary, which is why the working-dir level is required.)
+- px launch: px is configured via `--config=<path>` (equals form; a space-separated `--config <path>` is mis-parsed). Stopping uses the call operator with the quoted exe path (`& "<px>" --quit`) because `Invoke-CommandLine` evaluates the string via `Invoke-Expression`.
+- Process model: px runs a monitor process plus a worker process (both `pxw.exe`); this is normal and is not a duplicate instance.
 - SSPI evidence to look for when debugging: a working Kerberos exchange sends a large `Proxy-Authorization: Negotiate` token (thousands of bytes) and gets `200 Connection established`; an NTLM fallback sends a ~40-byte token and keeps getting `407`.
 - WSL reachability depends on `networkingMode=mirrored` in `.wslconfig` (Windows 11 22H2+). Under default NAT mode, `127.0.0.1` from WSL does not reach the Windows px; that scenario is out of scope for v1.
 - Do not store credentials anywhere: px uses the Windows logon session; no `--username`/`--password` and no `PX_PASSWORD`.

--- a/docs/backlog/sc-040.md
+++ b/docs/backlog/sc-040.md
@@ -1,0 +1,73 @@
+[← Back to Backlog](README.md)
+
+# [SC-040] Add Windows-side px authenticating proxy tool
+
+**Status**: Open
+**Priority**: High
+**Component**: `tools/proxy/px-proxy.ps1` (new), `tools/proxy/px-proxy.bat` (new), `tools/proxy/px-proxy.Tests.ps1` (new), `tools/proxy/setProxy.ps1`, `docs/px-proxy.md` (new), `README.md`, `docs/roadmap.md`
+**Related**: [SC-036](sc-036.md) (WSL-side Negotiate proxy, the sibling approach), [SC-007](sc-007.md) (setup-proxy Basic auth)
+
+**Summary**:
+As a developer behind a Kerberos/NTLM corporate proxy, I want a Windows-side tool that runs **px** as a local authenticating proxy on `127.0.0.1:3128` so that every native Windows tool *and* every WSL distro can reach the internet with no credentials stored anywhere, using my current Windows logon session (SSPI) for authentication.
+
+**Description**:
+`tools/proxy/setProxy.ps1` already resolves the corporate proxy from the PAC and sets `HTTP_PROXY`/`HTTPS_PROXY` for the PowerShell session, wiring `DefaultNetworkCredentials` into `[System.Net.WebRequest]::DefaultWebProxy`. That covers **.NET only**: native CLI tools (git, pip, node, curl, Claude Code) pointed straight at the corporate proxy cannot perform SSPI/Kerberos themselves and get `407 Proxy Authentication Required`.
+
+px closes that gap. On Windows, px authenticates to the upstream proxy via SSPI using the current logon session (auto-selects NTLM or Negotiate/Kerberos), and exposes a plain local proxy on `127.0.0.1:3128`. All tools point at that localhost endpoint; no password is entered or stored anywhere.
+
+This tool is **separate from wsl-manager**. It is a Windows-host concern and lives in `tools/proxy/` alongside `setProxy.ps1`. WSL distros reach the same `127.0.0.1:3128` because this machine runs WSL in `networkingMode=mirrored` (shared loopback), so one px instance serves both worlds.
+
+**Trial validation** (performed on the corporate network before writing this item):
+- px on Windows via SSPI produced a full Kerberos SPNEGO token and the proxy returned `200 Connection established` for google, api.anthropic.com and github. No password was entered.
+- From WSL (mirrored networking) `curl -x http://127.0.0.1:3128` returned HTTP 200 for both HTTP and HTTPS.
+- Root-cause finding: px must target the **real proxy host** (the one carrying the Kerberos SPN, resolved by evaluating the PAC), not the PAC-distribution/AutoConfigURL host. Pointing px at the AutoConfigURL host yields no SPN, SSPI falls back to NTLM, and the proxy rejects it (it also sends `Connection: close`, which breaks NTLM's multi-leg handshake).
+
+**Scope Decisions**:
+- **Separate single-purpose scripts, not a merge**: `px-proxy.ps1` owns the px daemon lifecycle (install/config/start/stop/test/remove); `setProxy.ps1` keeps owning per-session env vars and is extended to target `http://127.0.0.1:3128` when px is active. Keeps each script single-responsibility (SOLID).
+- **Not part of wsl-manager**: px on Windows is a Windows-host concern. wsl-manager stays focused on WSL-internal setup. This item does not modify wsl-manager or its `setup-proxy`.
+- **Proxy-host discovery by PAC evaluation, not the PAC host**: reuse `setProxy.ps1`'s `Get-ProxyFromPac` / `GetSystemWebProxy().GetProxy()` to resolve the actual upstream proxy the PAC hands out. This is what makes SSPI/Kerberos succeed. `klist` (looking for an `HTTP/<host>` service ticket) is a secondary confirmation/diagnostic only, because that ticket exists only after something has already authenticated this session.
+- **Install via Scoop (`main/px`)**: the `main` bucket manifest installs the official px binary ZIP from GitHub releases, satisfying both "Scoop-idiomatic for this repo" and "no pip bootstrap chicken-and-egg". Detect an existing px (Scoop shim or an existing pipx install) and skip install when already present.
+- **No autostart; Keypirinha-launched on demand**: px starts via the `.bat` wrapper (discoverable in Keypirinha) using `pxw.exe` (no console window). `px-proxy.ps1` exposes explicit `start` / `stop` actions rather than a registry Run key or Scheduled Task.
+- **TLS inspection / corporate CA is out of scope for v1**: the corporate root CA affects all TLS, not just px, and is environment-specific. Document the CA-trust prerequisite and the `curl --ssl-no-revoke` quirk (Schannel hard revocation check fails on the inspected cert when the revocation endpoint is unreachable) in troubleshooting; do not have this tool manage cert stores.
+
+**Acceptance Criteria**:
+- [ ] `tools/proxy/px-proxy.ps1` exists as a standalone script (`#Requires -Version 7.4`, `Set-StrictMode -Version Latest`, `Invoke-CommandLine` for external commands) with an action parameter supporting at least `install`, `start`, `stop`, `test`, `remove`
+- [ ] `tools/proxy/px-proxy.bat` wrapper exists (`pwsh -ExecutionPolicy Bypass -File %~dp0px-proxy.ps1 %*`) so the tool is launchable from Keypirinha
+- [ ] `install`: installs px via `scoop install px` (from the already-present `main` bucket) only when no px is detected (recognizes both a Scoop shim and an existing pipx px)
+- [ ] `install`: resolves the real upstream proxy host by PAC evaluation (reusing `setProxy.ps1`'s resolution logic) and writes a px config (`server = <resolved host:port>`, `listen = 127.0.0.1`, `port = 3128`, `auth` left empty for SSPI auto-discovery)
+- [ ] `install`: falls back to `klist`-derived `HTTP/<host>` SPN discovery (and finally a manual host prompt) when PAC evaluation yields DIRECT or no proxy
+- [ ] `start`: launches `pxw.exe` in the background if not already running (no console window); idempotent (no duplicate instance)
+- [ ] `stop`: stops any running px cleanly (`px --quit`, exit 0 even if none running)
+- [ ] `test`: performs an HTTPS request through `http://127.0.0.1:3128` (via `Invoke-WebRequest` using the Windows cert store) and reports success/failure with a clear diagnostic distinguishing a 407 (auth) from a TLS/cert error
+- [ ] `remove`: stops px, uninstalls it (only if this tool installed it via Scoop), and deletes the px config
+- [ ] `setProxy.ps1` gains an option to target `http://127.0.0.1:3128` (px) instead of the corporate proxy directly, so native CLI tools inherit working auth; default behavior for existing callers is unchanged unless the option is selected
+- [ ] Pester unit tests (`px-proxy.Tests.ps1`) cover each action, mocking `scoop`, px invocations, and the PAC/klist discovery branches (success + failure paths)
+- [ ] `docs/px-proxy.md` documents the tool: what it does, when to use it, the mirrored-networking requirement for WSL, and troubleshooting (corporate root-CA import, `curl --ssl-no-revoke`, checking `klist`, restarting px)
+- [ ] `README.md` (More Features) and `docs/roadmap.md` reference the new tool
+- [ ] All existing tests continue to pass
+
+**UAT Procedure** (run on a corporate Windows machine with the feature branch checked out):
+
+1. [ ] **Install**: run `px-proxy install`. Expect: px present (Scoop or detected pipx), a px config written with the PAC-resolved proxy host and `listen = 127.0.0.1`, `port = 3128`.
+2. [ ] **Start**: run `px-proxy start`. Expect: a `pxw.exe` process running, no console window, listening on `127.0.0.1:3128`.
+3. [ ] **Test (Windows)**: run `px-proxy test`. Expect: HTTPS request through `127.0.0.1:3128` returns success; no password prompted.
+4. [ ] **Native CLI**: with `setProxy.ps1` targeting px, run `git ls-remote https://github.com/...` (or `curl --ssl-no-revoke -x http://127.0.0.1:3128 https://github.com`). Expect: succeeds via SSPI, no credentials entered.
+5. [ ] **From WSL**: in a distro, `curl -x http://127.0.0.1:3128 https://www.google.com`. Expect: HTTP 200 (mirrored networking + trusted corporate CA in the distro).
+6. [ ] **Idempotent start**: run `px-proxy start` again. Expect: no second px instance.
+7. [ ] **Stop**: run `px-proxy stop`. Expect: px no longer running; a subsequent `test` reports failure clearly.
+8. [ ] **Remove**: run `px-proxy remove`. Expect: px stopped, config deleted, px uninstalled only if this tool installed it.
+
+**Technical Notes**:
+- Minimal px config (server mode, SSPI auto-discovery):
+  ```ini
+  [proxy]
+  server = <pac-resolved-host>:8080
+  port = 3128
+  listen = 127.0.0.1
+  auth =
+  ```
+- SSPI evidence to look for when debugging: a working Kerberos exchange sends a large `Proxy-Authorization: Negotiate` token (thousands of bytes) and gets `200 Connection established`; an NTLM fallback sends a ~40-byte token and keeps getting `407`.
+- WSL reachability depends on `networkingMode=mirrored` in `.wslconfig` (Windows 11 22H2+). Under default NAT mode, `127.0.0.1` from WSL does not reach the Windows px; that scenario is out of scope for v1.
+- Do not store credentials anywhere: px uses the Windows logon session; no `--username`/`--password` and no `PX_PASSWORD`.
+
+[← Back to Backlog](README.md)

--- a/docs/backlog/sc-040.md
+++ b/docs/backlog/sc-040.md
@@ -2,7 +2,7 @@
 
 # [SC-040] Add Windows-side px authenticating proxy tool
 
-**Status**: In Progress (implementation complete; UAT pending)
+**Status**: Done (2026-07-10)
 **Priority**: High
 **Component**: `tools/proxy/px-proxy.ps1` (new), `tools/proxy/px-proxy.bat` (new), `tools/proxy/px-proxy.Tests.ps1` (new), `tools/proxy/setProxy.ps1`, `docs/runbooks/px-proxy.md` (new), `README.md`, `docs/roadmap.md`
 **Related**: [SC-036](sc-036.md) (WSL-side Negotiate proxy, the sibling approach), [SC-007](sc-007.md) (setup-proxy Basic auth)
@@ -54,14 +54,16 @@ This tool is **separate from wsl-manager**. It is a Windows-host concern and liv
 
 **UAT Procedure** (run on a corporate Windows machine with the feature branch checked out):
 
-1. [ ] **Install**: run `px-proxy install`. Expect: px present (Scoop or detected pipx) and the px data directory created; no px config written yet (config is a `start`-time artifact).
-2. [ ] **Start**: run `px-proxy start`. Expect: the proxy resolved fresh, a px config (re)written with the PAC-resolved proxy host and `listen = 127.0.0.1`, `port = 3128`, `[settings] log = 3`; px running (a monitor plus worker `pxw.exe` process), no console window, listening on `127.0.0.1:3128`, and a `debug-*.log` written in the px data dir.
-3. [ ] **Test (Windows)**: run `px-proxy test`. Expect: HTTPS request through `127.0.0.1:3128` returns success; no password prompted.
-4. [ ] **Native CLI**: with `setProxy.ps1` targeting px, run `git ls-remote https://github.com/...` (or `curl --ssl-no-revoke -x http://127.0.0.1:3128 https://github.com`). Expect: succeeds via SSPI, no credentials entered.
-5. [ ] **From WSL**: in a distro, `curl -x http://127.0.0.1:3128 https://www.google.com`. Expect: HTTP 200 (mirrored networking + trusted corporate CA in the distro).
-6. [ ] **Restart on start**: run `px-proxy start` again. Expect: config regenerated, px restarted, no duplicate accumulation (still a single px monitor plus worker), reflecting the freshly-resolved proxy.
-7. [ ] **Stop**: run `px-proxy stop`. Expect: px no longer running; a subsequent `test` reports failure clearly.
-8. [ ] **Remove**: run `px-proxy remove`. Expect: px stopped, config and log file(s) deleted, px uninstalled only if this tool installed it.
+1. [x] **Install**: run `px-proxy install`. Expect: px present (Scoop or detected pipx) and the px data directory created; no px config written yet (config is a `start`-time artifact).
+2. [x] **Start**: run `px-proxy start`. Expect: the proxy resolved fresh, a px config (re)written with the PAC-resolved proxy host and `listen = 127.0.0.1`, `port = 3128`, `[settings] log = 3`; px running (a monitor plus worker `pxw.exe` process), no console window, listening on `127.0.0.1:3128`, and a `debug-*.log` written in the px data dir.
+3. [x] **Test (Windows)**: run `px-proxy test`. Expect: HTTPS request through `127.0.0.1:3128` returns success; no password prompted.
+4. [x] **Native CLI**: with `setProxy.ps1` targeting px, run `git ls-remote https://github.com/...` (or `curl --ssl-no-revoke -x http://127.0.0.1:3128 https://github.com`). Expect: succeeds via SSPI, no credentials entered.
+5. [x] **From WSL**: in a distro, `curl -x http://127.0.0.1:3128 https://www.google.com`. Expect: HTTP 200 (mirrored networking + trusted corporate CA in the distro).
+6. [x] **Restart on start**: run `px-proxy start` again. Expect: config regenerated, px restarted, no duplicate accumulation (still a single px monitor plus worker), reflecting the freshly-resolved proxy.
+7. [x] **Stop**: run `px-proxy stop`. Expect: px no longer running; a subsequent `test` reports failure clearly.
+8. [x] **Remove**: run `px-proxy remove`. Expect: px stopped, config and log file(s) deleted, px uninstalled only if this tool installed it.
+
+**UAT outcome** (2026-07-10): all eight steps passed on the corporate network. This also settles the two config semantics that unit tests could not confirm without the real px binary: an empty `auth =` is accepted by px (SSPI auto-discovery), and `[settings] log = 3` writes a unique `debug-<pid>.log` into px's working directory.
 
 **Technical Notes**:
 - Minimal px config (server mode, SSPI auto-discovery, logging enabled):

--- a/docs/backlog/sc-040.md
+++ b/docs/backlog/sc-040.md
@@ -4,7 +4,7 @@
 
 **Status**: Open
 **Priority**: High
-**Component**: `tools/proxy/px-proxy.ps1` (new), `tools/proxy/px-proxy.bat` (new), `tools/proxy/px-proxy.Tests.ps1` (new), `tools/proxy/setProxy.ps1`, `docs/px-proxy.md` (new), `README.md`, `docs/roadmap.md`
+**Component**: `tools/proxy/px-proxy.ps1` (new), `tools/proxy/px-proxy.bat` (new), `tools/proxy/px-proxy.Tests.ps1` (new), `tools/proxy/setProxy.ps1`, `docs/runbooks/px-proxy.md` (new), `README.md`, `docs/roadmap.md`
 **Related**: [SC-036](sc-036.md) (WSL-side Negotiate proxy, the sibling approach), [SC-007](sc-007.md) (setup-proxy Basic auth)
 
 **Summary**:
@@ -25,6 +25,7 @@ This tool is **separate from wsl-manager**. It is a Windows-host concern and liv
 **Scope Decisions**:
 - **Separate single-purpose scripts, not a merge**: `px-proxy.ps1` owns the px daemon lifecycle (install/config/start/stop/test/remove); `setProxy.ps1` keeps owning per-session env vars and is extended to target `http://127.0.0.1:3128` when px is active. Keeps each script single-responsibility (SOLID).
 - **Not part of wsl-manager**: px on Windows is a Windows-host concern. wsl-manager stays focused on WSL-internal setup. This item does not modify wsl-manager or its `setup-proxy`.
+- **Config is regenerated at `start`, not `install`**: `install` only handles the px binary and data directory; it never resolves the proxy or writes config. `start` resolves the upstream proxy fresh and rewrites the config every time, then always restarts px so the running instance reflects the current network. This avoids stale proxy hosts when roaming networks or when the PAC output changes, at the cost of an unconditional restart on `start` (accepted for simplicity and correctness).
 - **Proxy-host discovery by PAC evaluation, not the PAC host**: reuse `setProxy.ps1`'s `Get-ProxyFromPac` / `GetSystemWebProxy().GetProxy()` to resolve the actual upstream proxy the PAC hands out. This is what makes SSPI/Kerberos succeed. `klist` (looking for an `HTTP/<host>` service ticket) is a secondary confirmation/diagnostic only, because that ticket exists only after something has already authenticated this session.
 - **Install via Scoop (`main/px`)**: the `main` bucket manifest installs the official px binary ZIP from GitHub releases, satisfying both "Scoop-idiomatic for this repo" and "no pip bootstrap chicken-and-egg". Detect an existing px (Scoop shim or an existing pipx install) and skip install when already present.
 - **No autostart; Keypirinha-launched on demand**: px starts via the `.bat` wrapper (discoverable in Keypirinha) using `pxw.exe` (no console window). `px-proxy.ps1` exposes explicit `start` / `stop` actions rather than a registry Run key or Scheduled Task.
@@ -33,39 +34,44 @@ This tool is **separate from wsl-manager**. It is a Windows-host concern and liv
 **Acceptance Criteria**:
 - [ ] `tools/proxy/px-proxy.ps1` exists as a standalone script (`#Requires -Version 7.4`, `Set-StrictMode -Version Latest`, `Invoke-CommandLine` for external commands) with an action parameter supporting at least `install`, `start`, `stop`, `test`, `remove`
 - [ ] `tools/proxy/px-proxy.bat` wrapper exists (`pwsh -ExecutionPolicy Bypass -File %~dp0px-proxy.ps1 %*`) so the tool is launchable from Keypirinha
-- [ ] `install`: installs px via `scoop install px` (from the already-present `main` bucket) only when no px is detected (recognizes both a Scoop shim and an existing pipx px)
-- [ ] `install`: resolves the real upstream proxy host by PAC evaluation (reusing `setProxy.ps1`'s resolution logic) and writes a px config (`server = <resolved host:port>`, `listen = 127.0.0.1`, `port = 3128`, `auth` left empty for SSPI auto-discovery)
-- [ ] `install`: falls back to `klist`-derived `HTTP/<host>` SPN discovery (and finally a manual host prompt) when PAC evaluation yields DIRECT or no proxy
-- [ ] `start`: launches `pxw.exe` in the background if not already running (no console window); idempotent (no duplicate instance)
+- [ ] `install`: installs px via `scoop install px` (from the already-present `main` bucket) only when no px is detected (recognizes both a Scoop shim and an existing pipx px), and ensures the tool's px data directory exists; `install` does **not** resolve the proxy or write any px config (that is `start`'s job)
+- [ ] `start`: resolves the real upstream proxy fresh on every invocation by PAC evaluation (reusing `setProxy.ps1`'s `Get-ProxyFromPac`, which runs the PAC's `FindProxyForURL` via `GetSystemWebProxy().GetProxy()` and returns a `scheme://host:port` URL for the real upstream proxy, not the PAC-distribution host), parsing the bare `host:port` out of that URL's authority (scheme stripped)
+- [ ] `start`: falls back to `klist`-derived `HTTP/<host>` SPN discovery (and finally a manual host prompt) when PAC evaluation yields DIRECT or no proxy
+- [ ] `start`: (re)writes the px config every time from the freshly-resolved proxy (`server = <resolved host:port>`, `listen = 127.0.0.1`, `port = 3128`, `auth` empty for SSPI auto-discovery, `[settings] log = 1` so a log file is written on startup) into the px data directory, overwriting any previous config
+- [ ] `start`: always (re)starts px to guarantee it reflects the freshly-written config: stops any already-running px, then launches `pxw.exe` in the background (no console window) with its working directory set to the px data dir so the log lands there; the result is exactly one running px instance
 - [ ] `stop`: stops any running px cleanly (`px --quit`, exit 0 even if none running)
-- [ ] `test`: performs an HTTPS request through `http://127.0.0.1:3128` (via `Invoke-WebRequest` using the Windows cert store) and reports success/failure with a clear diagnostic distinguishing a 407 (auth) from a TLS/cert error
-- [ ] `remove`: stops px, uninstalls it (only if this tool installed it via Scoop), and deletes the px config
+- [ ] `test`: performs an HTTPS request through `http://127.0.0.1:3128` (via `Invoke-WebRequest` using the Windows cert store) and reports success/failure with a clear diagnostic distinguishing a 407 (auth) from a TLS/cert error; accounts for the Schannel hard-revocation quirk (the `curl --ssl-no-revoke` equivalent) so an unreachable revocation endpoint on the inspected cert is surfaced as a distinct, non-fatal diagnostic rather than a generic failure, and points the user at the px log on failure
+- [ ] `remove`: stops px, uninstalls it (only if this tool installed it via Scoop), and deletes the px config and its log file(s)
 - [ ] `setProxy.ps1` gains an option to target `http://127.0.0.1:3128` (px) instead of the corporate proxy directly, so native CLI tools inherit working auth; default behavior for existing callers is unchanged unless the option is selected
 - [ ] Pester unit tests (`px-proxy.Tests.ps1`) cover each action, mocking `scoop`, px invocations, and the PAC/klist discovery branches (success + failure paths)
-- [ ] `docs/px-proxy.md` documents the tool: what it does, when to use it, the mirrored-networking requirement for WSL, and troubleshooting (corporate root-CA import, `curl --ssl-no-revoke`, checking `klist`, restarting px)
+- [ ] `docs/runbooks/px-proxy.md` documents the tool: what it does, when to use it, the mirrored-networking requirement for WSL, where the px log file lives, and troubleshooting (corporate root-CA import, `curl --ssl-no-revoke`, reading the px log, checking `klist`, restarting px)
 - [ ] `README.md` (More Features) and `docs/roadmap.md` reference the new tool
 - [ ] All existing tests continue to pass
 
 **UAT Procedure** (run on a corporate Windows machine with the feature branch checked out):
 
-1. [ ] **Install**: run `px-proxy install`. Expect: px present (Scoop or detected pipx), a px config written with the PAC-resolved proxy host and `listen = 127.0.0.1`, `port = 3128`.
-2. [ ] **Start**: run `px-proxy start`. Expect: a `pxw.exe` process running, no console window, listening on `127.0.0.1:3128`.
+1. [ ] **Install**: run `px-proxy install`. Expect: px present (Scoop or detected pipx) and the px data directory created; no px config written yet (config is a `start`-time artifact).
+2. [ ] **Start**: run `px-proxy start`. Expect: the proxy resolved fresh, a px config (re)written with the PAC-resolved proxy host and `listen = 127.0.0.1`, `port = 3128`, `[settings] log = 1`; a single `pxw.exe` process running, no console window, listening on `127.0.0.1:3128`, and a `debug-<pid>.log` written in the px data dir.
 3. [ ] **Test (Windows)**: run `px-proxy test`. Expect: HTTPS request through `127.0.0.1:3128` returns success; no password prompted.
 4. [ ] **Native CLI**: with `setProxy.ps1` targeting px, run `git ls-remote https://github.com/...` (or `curl --ssl-no-revoke -x http://127.0.0.1:3128 https://github.com`). Expect: succeeds via SSPI, no credentials entered.
 5. [ ] **From WSL**: in a distro, `curl -x http://127.0.0.1:3128 https://www.google.com`. Expect: HTTP 200 (mirrored networking + trusted corporate CA in the distro).
-6. [ ] **Idempotent start**: run `px-proxy start` again. Expect: no second px instance.
+6. [ ] **Restart on start**: run `px-proxy start` again. Expect: config regenerated, px restarted, still exactly one `pxw.exe` instance (no duplicates), reflecting the freshly-resolved proxy.
 7. [ ] **Stop**: run `px-proxy stop`. Expect: px no longer running; a subsequent `test` reports failure clearly.
-8. [ ] **Remove**: run `px-proxy remove`. Expect: px stopped, config deleted, px uninstalled only if this tool installed it.
+8. [ ] **Remove**: run `px-proxy remove`. Expect: px stopped, config and log file(s) deleted, px uninstalled only if this tool installed it.
 
 **Technical Notes**:
-- Minimal px config (server mode, SSPI auto-discovery):
+- Minimal px config (server mode, SSPI auto-discovery, logging enabled):
   ```ini
   [proxy]
   server = <pac-resolved-host>:8080
-  port = 3128
   listen = 127.0.0.1
+  port = 3128
   auth =
+
+  [settings]
+  log = 1
   ```
+- Logging: `[settings] log = 1` makes px write a `debug-<pid>.log` in its working directory. Start `pxw.exe` with its working directory set to the tool's px data dir (where the config lives) so the log lands in a stable, known location that `test` and troubleshooting can point at. `remove` deletes these log files.
 - SSPI evidence to look for when debugging: a working Kerberos exchange sends a large `Proxy-Authorization: Negotiate` token (thousands of bytes) and gets `200 Connection established`; an NTLM fallback sends a ~40-byte token and keeps getting `407`.
 - WSL reachability depends on `networkingMode=mirrored` in `.wslconfig` (Windows 11 22H2+). Under default NAT mode, `127.0.0.1` from WSL does not reach the Windows px; that scenario is out of scope for v1.
 - Do not store credentials anywhere: px uses the Windows logon session; no `--username`/`--password` and no `PX_PASSWORD`.

--- a/docs/backlog/sc-040.md
+++ b/docs/backlog/sc-040.md
@@ -2,7 +2,7 @@
 
 # [SC-040] Add Windows-side px authenticating proxy tool
 
-**Status**: Done (2026-07-09)
+**Status**: In Progress (implementation complete; UAT pending)
 **Priority**: High
 **Component**: `tools/proxy/px-proxy.ps1` (new), `tools/proxy/px-proxy.bat` (new), `tools/proxy/px-proxy.Tests.ps1` (new), `tools/proxy/setProxy.ps1`, `docs/runbooks/px-proxy.md` (new), `README.md`, `docs/roadmap.md`
 **Related**: [SC-036](sc-036.md) (WSL-side Negotiate proxy, the sibling approach), [SC-007](sc-007.md) (setup-proxy Basic auth)
@@ -41,7 +41,10 @@ This tool is **separate from wsl-manager**. It is a Windows-host concern and liv
 - [x] `start`: always (re)starts px to guarantee it reflects the freshly-written config: stops any already-running px, then launches `pxw.exe` in the background (no console window) with its working directory set to the px data dir so the log lands there; the result is exactly one px instance (px itself runs a monitor plus worker process; a repeated `start` does not accumulate duplicates)
 - [x] `stop`: stops any running px cleanly (`px --quit`, exit 0 even if none running)
 - [x] `test`: performs an HTTPS request through `http://127.0.0.1:3128` (via `Invoke-WebRequest` using the Windows cert store) and reports success/failure with a clear diagnostic distinguishing a 407 (auth) from a TLS/cert error; accounts for the Schannel hard-revocation quirk (the `curl --ssl-no-revoke` equivalent) so an unreachable revocation endpoint on the inspected cert is surfaced as a distinct, non-fatal diagnostic rather than a generic failure, and points the user at the px log on failure
-- [x] `remove`: stops px, uninstalls it (only if this tool installed it via Scoop), and deletes the px config and its log file(s)
+- [x] `test`: exits non-zero when the probe fails, so `px-proxy.bat` and scripted callers can detect it (the diagnostic warning is still printed)
+- [x] `start`: fails fast when no px executable is present — before resolving the proxy (which may prompt) and before writing any config
+- [x] `remove`: stops px, uninstalls it (only if this tool installed it via Scoop), and deletes the px config and its log file(s); when px is not on `PATH` the uninstall is skipped and the install marker is **kept**, so a later `remove` can still clean up
+- [x] The `klist` SPN fallback warns that both the host (first `HTTP/` ticket in the cache) and the port (default `8080`) are guesses, and points at `-ProxyHost`
 - [x] `setProxy.ps1` gains an option to target `http://127.0.0.1:3128` (px) instead of the corporate proxy directly, so native CLI tools inherit working auth; default behavior for existing callers is unchanged unless the option is selected
 - [x] `setProxy.ps1` auto-detects a running px (TCP probe on the px endpoint) and targets it automatically without requiring `-UsePx`; `-NoPx` forces the corporate-proxy path and `-UsePx` still forces px unconditionally
 - [x] Pester unit tests (`px-proxy.Tests.ps1`) cover each action, mocking `scoop`, px invocations, and the PAC/klist discovery branches (success + failure paths)

--- a/docs/backlog/sc-041.md
+++ b/docs/backlog/sc-041.md
@@ -1,0 +1,33 @@
+[← Back to Backlog](README.md)
+
+# [SC-041] ✅ DONE - Move tool-specific documentation into docs/runbooks/
+
+**Status**: Done (2026-07-09)
+**Priority**: Medium
+**Component**: `docs/flow-launcher-setup.md`, `README.md`
+
+**Related**: [SC-040](sc-040.md) (px-proxy tool, whose new doc already targets `docs/runbooks/`), [SC-004](sc-004.md) (documentation consolidation)
+
+**Summary**:
+As a contributor, I want operational tool setup guides to live under a `docs/runbooks/` folder, so that step-by-step runbooks are grouped together and easy to find, separate from comprehensive tool specifications, architecture, and process docs.
+
+**Description**:
+Operational tool setup guides sit directly in `docs/` alongside process/reference docs (`development-principles.md`, `roadmap.md`) and the `architecture/` subfolder. A dedicated `docs/runbooks/` folder keeps these step-by-step guides grouped and discoverable (px-proxy in SC-040 already targets `docs/runbooks/px-proxy.md`).
+
+Only operational runbooks move. `docs/wsl-manager.md` is a comprehensive tool specification (commands, reference, DevContainer walkthrough), not an operational runbook, so it stays in `docs/`. This item moves `flow-launcher-setup.md` and updates all **live** references. Historical backlog entries that mention the old path are left untouched: they are a record of what was true at the time and must not be rewritten.
+
+**Scope Decisions**:
+- **Folder name is `runbooks` (plural)**, matching the "one runbook per tool setup" mental model.
+- **Move only operational setup guides**: `flow-launcher-setup.md`. Comprehensive tool specs (`wsl-manager.md`), process/reference docs (`development-principles.md`, `roadmap.md`), and the `architecture/` subfolder stay where they are. `wsl-manager.md` is explicitly kept in `docs/` because it is a full tool spec, not a runbook.
+- **Update live references only**: `README.md`. Do not rewrite historical backlog files under `docs/backlog/` that reference the old path.
+- **Use `git mv`** to preserve file history.
+
+**Acceptance Criteria**:
+- [x] `docs/runbooks/` directory exists
+- [x] `docs/flow-launcher-setup.md` moved to `docs/runbooks/flow-launcher-setup.md` (via `git mv`, history preserved)
+- [x] `docs/wsl-manager.md` remains in `docs/` (not a runbook)
+- [x] `README.md` link updated to the new `docs/runbooks/` path (Flow Launcher entry)
+- [x] No live (non-historical) references to the old `docs/flow-launcher-setup.md` path remain; historical `docs/backlog/*.md` entries are left unchanged
+- [x] All existing tests continue to pass
+
+[← Back to Backlog](README.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,6 +28,7 @@ Provide a seamless, keyboard-driven Windows automation experience through Keypir
 - Additional shortcuts and utilities
 - Improved Scoop integration
 - Enhanced tool installation workflows
+- Corporate proxy support: a Windows-side local authenticating proxy (px) providing seamless SSPI/Kerberos auth for native and WSL tools
 
 ### PowerShell Modernization
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,7 @@ Provide a seamless, keyboard-driven Windows automation experience through Keypir
 - Additional shortcuts and utilities
 - Improved Scoop integration
 - Enhanced tool installation workflows
-- Corporate proxy support: a Windows-side local authenticating proxy (px) providing seamless SSPI/Kerberos auth for native and WSL tools
+- Corporate proxy support: a Windows-side local authenticating proxy ([px](runbooks/px-proxy.md)) providing seamless SSPI/Kerberos auth for native and WSL tools
 
 ### PowerShell Modernization
 

--- a/docs/runbooks/flow-launcher-setup.md
+++ b/docs/runbooks/flow-launcher-setup.md
@@ -1,4 +1,4 @@
-[← Back to README](../README.md)
+[← Back to README](../../README.md)
 
 # Flow Launcher Setup Guide
 
@@ -397,4 +397,4 @@ Flow Launcher supports advanced query syntax:
 
 ---
 
-[← Back to README](../README.md)
+[← Back to README](../../README.md)

--- a/docs/runbooks/px-proxy.md
+++ b/docs/runbooks/px-proxy.md
@@ -1,0 +1,128 @@
+[← Back to README](../../README.md)
+
+# px Proxy Runbook
+
+## Overview
+
+`px-proxy` runs [px](https://github.com/genotrance/px) as a local authenticating proxy on `http://127.0.0.1:3128`. px authenticates to your corporate upstream proxy using your current Windows logon session (SSPI: NTLM or Negotiate/Kerberos) and exposes a plain, credential-free local endpoint. Point native Windows CLI tools (git, pip, node, curl, Claude Code) and WSL distros at that endpoint and they reach the internet without storing any password.
+
+**Why this exists:** `setProxy.ps1` wires the corporate proxy into `[System.Net.WebRequest]::DefaultWebProxy`, which only covers .NET. Native CLI tools cannot perform SSPI themselves and get `407 Proxy Authentication Required` when pointed straight at the corporate proxy. px closes that gap.
+
+**When to use it:** you are behind a Kerberos/NTLM corporate proxy and need native tools (and/or WSL) to reach the internet without embedding credentials.
+
+---
+
+## Prerequisites
+
+- Windows with your normal corporate domain logon (px reuses this session for SSPI).
+- [Scoop](https://scoop.sh) installed (`px` comes from the `main` bucket).
+- The corporate root CA trusted in the Windows certificate store (px does not manage certificates).
+- **For WSL reachability:** `networkingMode=mirrored` in `.wslconfig` (Windows 11 22H2+). Under default NAT mode, `127.0.0.1` from WSL does not reach the Windows px; that scenario is out of scope.
+
+---
+
+## Usage
+
+Run from Keypirinha (type `px-proxy`) or from a terminal:
+
+```powershell
+.\tools\proxy\px-proxy.ps1 <action>
+```
+
+| Action    | What it does |
+|-----------|--------------|
+| `install` | Installs px via Scoop (only if not already present) and creates the px data directory. Does **not** resolve the proxy or write config. |
+| `start`   | Resolves the upstream proxy fresh, (re)writes the px config, and always (re)starts px. Exactly one `pxw.exe` instance results. |
+| `stop`    | Stops any running px cleanly. |
+| `test`    | Sends an HTTPS request through `127.0.0.1:3128` and reports a clear diagnostic. |
+| `remove`  | Stops px, uninstalls it (only if this tool installed it), and deletes the config and log files. |
+
+`start` is the default action when none is given.
+
+### Manual upstream override
+
+If auto-discovery cannot resolve the proxy (PAC returns DIRECT and no Kerberos SPN is present), pass the host explicitly:
+
+```powershell
+.\tools\proxy\px-proxy.ps1 start -ProxyHost "proxy.corp.example:8080"
+```
+
+### Pointing tools at px
+
+### Pointing tools at px
+
+Once px is running, `setProxy.ps1` **auto-detects** it (a TCP probe on the px endpoint) and targets it automatically, no switch needed:
+
+```powershell
+.\tools\proxy\setProxy.ps1
+```
+
+Force the behavior either way:
+
+```powershell
+.\tools\proxy\setProxy.ps1 -UsePx   # always use px, even if the probe fails
+.\tools\proxy\setProxy.ps1 -NoPx    # ignore px, force the corporate-proxy path
+```
+
+`setProxy.ps1` sets `HTTP_PROXY`/`HTTPS_PROXY` (and `DefaultWebProxy`) for the current session only; open a new shell and re-run it if needed.
+
+From WSL (mirrored networking):
+
+```bash
+curl -x http://127.0.0.1:3128 https://www.google.com
+```
+
+---
+
+## How discovery works
+
+1. **`-ProxyHost` override** (if provided) wins.
+2. **PAC evaluation**: reuses `setProxy.ps1`'s `Get-ProxyFromPac`, which runs the PAC's `FindProxyForURL` via `GetSystemWebProxy().GetProxy()` and returns the **real upstream proxy** (the host carrying the Kerberos SPN), not the PAC-distribution host.
+3. **Kerberos SPN fallback**: parses an `HTTP/<host>` service ticket from `klist` and appends the default port `8080`.
+4. **Manual prompt**: interactive sessions only.
+
+> **Root-cause note:** px must target the real proxy host (the one carrying the Kerberos SPN). Pointing px at the PAC-distribution / AutoConfigURL host yields no SPN, SSPI falls back to NTLM, and the proxy rejects it.
+
+---
+
+## Files and logs
+
+- **Data directory:** `%USERPROFILE%\.config\px`
+- **Config:** `%USERPROFILE%\.config\px\px.ini` (regenerated on every `start`)
+- **Log:** `%USERPROFILE%\.config\px\debug-*.log` (`[settings] log = 3` writes a unique log in px's working directory, which `start` sets to the data dir; `remove` deletes these)
+
+---
+
+## Troubleshooting
+
+### `407 Proxy Authentication Required`
+
+px could not authenticate to the upstream proxy. Confirm the resolved proxy host carries a Kerberos SPN:
+
+```powershell
+klist
+```
+
+Look for a `Server: HTTP/<host>` ticket. A working Kerberos exchange sends a large `Proxy-Authorization: Negotiate` token (thousands of bytes) and gets `200 Connection established`; an NTLM fallback sends a ~40-byte token and keeps getting `407`. If px is pointed at the wrong host, override it with `-ProxyHost`.
+
+### TLS revocation check failed (`curl --ssl-no-revoke` scenario)
+
+Behind TLS inspection, Schannel's hard revocation check can fail when the revocation endpoint of the inspected certificate is unreachable. This is often benign. `px-proxy test` surfaces it as a distinct diagnostic. Ensure the corporate root CA is trusted; for `curl`, `--ssl-no-revoke` bypasses the check.
+
+### TLS / certificate errors
+
+Import the corporate root CA into the Windows trust store (and, for WSL, into the distro's CA bundle).
+
+### Nothing works / connection refused
+
+Confirm px is running and reachable:
+
+```powershell
+.\tools\proxy\px-proxy.ps1 test
+```
+
+Then read the px log at `%USERPROFILE%\.config\px\debug-*.log`. Re-run `start` to regenerate the config and restart px.
+
+---
+
+[← Back to README](../../README.md)

--- a/docs/runbooks/px-proxy.md
+++ b/docs/runbooks/px-proxy.md
@@ -49,8 +49,6 @@ If auto-discovery cannot resolve the proxy (PAC returns DIRECT and no Kerberos S
 
 ### Pointing tools at px
 
-### Pointing tools at px
-
 Once px is running, `setProxy.ps1` **auto-detects** it (a TCP probe on the px endpoint) and targets it automatically, no switch needed:
 
 ```powershell

--- a/tools/proxy/px-proxy.Tests.ps1
+++ b/tools/proxy/px-proxy.Tests.ps1
@@ -1,0 +1,304 @@
+﻿#Requires -Version 7.4
+#Requires -Modules @{ModuleName = 'Pester'; ModuleVersion = '5.2.0'}
+
+<#
+.SYNOPSIS
+    Unit tests for px-proxy.ps1
+
+.DESCRIPTION
+    Tests the local px authenticating proxy management tool following a TDD
+    approach. External side effects (Scoop, processes, web requests, klist) are
+    mocked; the px data directory is redirected to TestDrive.
+#>
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Mock function parameters are required by the interface but may not be used in test implementations')]
+param()
+
+BeforeAll {
+    . "$PSScriptRoot\..\..\test\bin\lib\TestIsolation.ps1"
+    # Prevent auto-execution of main when dot-sourcing
+    $env:PXPROXY_LIBRARY_MODE = '1'
+
+    Start-SutIsolation
+    . "$PSScriptRoot\px-proxy.ps1"
+
+    $script:TestDataDir = Join-Path $TestDrive '.config\px'
+}
+
+AfterAll {
+    Remove-Item Env:\PXPROXY_LIBRARY_MODE -ErrorAction SilentlyContinue
+    Stop-SutIsolation
+}
+
+Describe "Get-PxDataDir" {
+    It "returns a path under the user profile .config\px" {
+        Get-PxDataDir | Should -BeLike '*\.config\px'
+    }
+}
+
+Describe "Get-PxConfigPath" {
+    It "returns px.ini inside the data directory" {
+        Mock Get-PxDataDir { 'C:\fake\px' }
+        Get-PxConfigPath | Should -Be 'C:\fake\px\px.ini'
+    }
+}
+
+Describe "Test-PxInstalled" {
+    It "returns true when px command is found" {
+        Mock Get-Command { [pscustomobject]@{ Source = 'C:\scoop\shims\px.exe' } } -ParameterFilter { $Name -eq 'px' }
+        Test-PxInstalled | Should -BeTrue
+    }
+
+    It "returns false when px command is missing" {
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'px' }
+        Test-PxInstalled | Should -BeFalse
+    }
+}
+
+Describe "Get-PxExecutable" {
+    It "prefers pxw when Windowless is requested and pxw exists" {
+        Mock Get-Command { [pscustomobject]@{ Source = 'C:\scoop\shims\pxw.exe' } } -ParameterFilter { $Name -eq 'pxw' }
+        Get-PxExecutable -Windowless | Should -Be 'C:\scoop\shims\pxw.exe'
+    }
+
+    It "falls back to px when the requested variant shim is missing" {
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'pxw' }
+        Mock Get-Command { [pscustomobject]@{ Source = 'C:\scoop\shims\px.exe' } } -ParameterFilter { $Name -eq 'px' }
+        Mock Test-Path { $false }
+        Get-PxExecutable -Windowless | Should -Be 'C:\scoop\shims\px.exe'
+    }
+
+    It "returns null when no px executable exists" {
+        Mock Get-Command { $null }
+        Get-PxExecutable | Should -BeNullOrEmpty
+    }
+}
+
+Describe "Get-KerberosProxyHost" {
+    It "extracts the HTTP SPN host and appends the default port" {
+        Mock Get-KlistOutput { @(
+                'Cached Tickets: (5)',
+                '    Server: HTTP/osproxy.corp.example @ CORP.EXAMPLE'
+            ) }
+        Get-KerberosProxyHost | Should -Be 'osproxy.corp.example:8080'
+    }
+
+    It "returns null when no HTTP SPN is present" {
+        Mock Get-KlistOutput { @('Cached Tickets: (1)', '    Server: krbtgt/CORP.EXAMPLE') }
+        Get-KerberosProxyHost | Should -BeNullOrEmpty
+    }
+
+    It "returns null when klist output is empty" {
+        Mock Get-KlistOutput { $null }
+        Get-KerberosProxyHost | Should -BeNullOrEmpty
+    }
+}
+
+Describe "Resolve-PxUpstreamProxy" {
+    It "returns the explicit ProxyHost override when provided" {
+        Resolve-PxUpstreamProxy -ProxyHost 'manual.corp:8080' | Should -Be 'manual.corp:8080'
+    }
+
+    It "resolves via PAC when the PAC returns a non-direct proxy" {
+        Mock Get-InternetSettingsFromRegistry { @{ AutoConfigUrl = 'http://wpad/pac' } }
+        Mock Get-ProxyFromPac { @{ ProxyUrl = 'http://pacproxy.corp:8080'; IsDirect = $false } }
+        Resolve-PxUpstreamProxy | Should -Be 'pacproxy.corp:8080'
+    }
+
+    It "falls back to the Kerberos SPN when PAC is direct" {
+        Mock Get-InternetSettingsFromRegistry { @{ } }
+        Mock Get-ProxyFromPac { @{ ProxyUrl = $null; IsDirect = $true } }
+        Mock Get-KerberosProxyHost { 'spnproxy.corp:8080' }
+        Resolve-PxUpstreamProxy | Should -Be 'spnproxy.corp:8080'
+    }
+
+    It "throws when nothing resolves in a non-interactive session" {
+        Mock Get-InternetSettingsFromRegistry { $null }
+        Mock Get-KerberosProxyHost { $null }
+        Mock Test-RunningInCIorTestEnvironment { $true }
+        { Resolve-PxUpstreamProxy } | Should -Throw
+    }
+}
+
+Describe "Write-PxConfig" {
+    BeforeEach {
+        Mock Get-PxDataDir { $script:TestDataDir }
+        Mock New-Directory { New-Item -ItemType Directory -Path $Path -Force | Out-Null }
+    }
+
+    It "writes a px.ini containing the resolved upstream proxy and logging" {
+        $path = Write-PxConfig -UpstreamProxy 'up.corp:8080'
+        $path | Should -Be (Join-Path $script:TestDataDir 'px.ini')
+        $content = Get-Content -Raw $path
+        $content | Should -Match 'server = up\.corp:8080'
+        $content | Should -Match 'listen = 127\.0\.0\.1'
+        $content | Should -Match 'port = 3128'
+        $content | Should -Match 'log = 3'
+    }
+
+    It "overwrites an existing config on each call" {
+        Write-PxConfig -UpstreamProxy 'first.corp:8080' | Out-Null
+        $path = Write-PxConfig -UpstreamProxy 'second.corp:8080'
+        $content = Get-Content -Raw $path
+        $content | Should -Match 'server = second\.corp:8080'
+        $content | Should -Not -Match 'first\.corp'
+    }
+}
+
+Describe "Install-PxProxy" {
+    BeforeEach {
+        Mock Get-PxDataDir { $script:TestDataDir }
+        Mock New-Directory { New-Item -ItemType Directory -Path $Path -Force | Out-Null }
+        Mock Invoke-CommandLine { }
+    }
+
+    It "installs px via Scoop and writes a marker when px is absent" {
+        Mock Test-PxInstalled { $false }
+        Install-PxProxy
+        Should -Invoke Invoke-CommandLine -Times 1 -ParameterFilter { $CommandLine -eq 'scoop install px' }
+        Test-Path (Get-PxInstalledMarkerPath) | Should -BeTrue
+    }
+
+    It "skips Scoop install when px is already present" {
+        Mock Test-PxInstalled { $true }
+        Install-PxProxy
+        Should -Invoke Invoke-CommandLine -Times 0
+    }
+}
+
+Describe "Stop-PxProxy" {
+    It "does nothing when px is not running" {
+        Mock Test-PxRunning { $false }
+        Mock Invoke-CommandLine { }
+        Stop-PxProxy
+        Should -Invoke Invoke-CommandLine -Times 0
+    }
+
+    It "asks px to quit when running" {
+        Mock Test-PxRunning { $true } -ParameterFilter { $true }
+        Mock Get-PxExecutable { 'C:\scoop\shims\px.exe' }
+        Mock Invoke-CommandLine { }
+        Mock Start-Sleep { }
+        # After quit, no longer running
+        $script:quitCalled = $false
+        Mock Test-PxRunning { if ($script:quitCalled) { $false } else { $script:quitCalled = $true; $true } }
+        Stop-PxProxy
+        Should -Invoke Invoke-CommandLine -Times 1 -ParameterFilter { $CommandLine -match '^& ".*" --quit$' }
+    }
+}
+
+Describe "Start-PxProxy" {
+    BeforeEach {
+        Mock Get-PxDataDir { $script:TestDataDir }
+        Mock New-Directory { New-Item -ItemType Directory -Path $Path -Force | Out-Null }
+        Mock Resolve-PxUpstreamProxy { 'up.corp:8080' }
+        Mock Get-PxExecutable { 'C:\scoop\shims\pxw.exe' }
+        Mock Test-PxRunning { $false }
+        Mock Start-Process { }
+    }
+
+    It "resolves, writes config, and starts px" {
+        Start-PxProxy
+        Should -Invoke Resolve-PxUpstreamProxy -Times 1
+        Should -Invoke Start-Process -Times 1 -ParameterFilter {
+            $FilePath -eq 'C:\scoop\shims\pxw.exe' -and $ArgumentList -match '^--config='
+        }
+        Test-Path (Join-Path $script:TestDataDir 'px.ini') | Should -BeTrue
+    }
+
+    It "stops a running px before starting a fresh one" {
+        Mock Test-PxRunning { $true }
+        Mock Stop-PxProxy { }
+        Start-PxProxy
+        Should -Invoke Stop-PxProxy -Times 1
+        Should -Invoke Start-Process -Times 1
+    }
+
+    It "throws when no px executable is available" {
+        Mock Get-PxExecutable { $null }
+        { Start-PxProxy } | Should -Throw
+    }
+}
+
+Describe "Test-PxProxy" {
+    It "reports success on a 200 response" {
+        Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 200 } }
+        Test-PxProxy | Should -BeTrue
+    }
+
+    It "reports failure and returns false on a 407" {
+        Mock Invoke-WebRequest {
+            $resp = [pscustomobject]@{ StatusCode = 407 }
+            $ex = [System.Exception]::new('Proxy auth required')
+            $ex | Add-Member -NotePropertyName Response -NotePropertyValue $resp -Force
+            throw $ex
+        }
+        Test-PxProxy -WarningAction SilentlyContinue | Should -BeFalse
+    }
+
+    It "returns false on a generic error" {
+        Mock Invoke-WebRequest { throw 'connection refused' }
+        Test-PxProxy -WarningAction SilentlyContinue | Should -BeFalse
+    }
+}
+
+Describe "Remove-PxProxy" {
+    BeforeEach {
+        Mock Get-PxDataDir { $script:TestDataDir }
+        Mock Stop-PxProxy { }
+        Mock Invoke-CommandLine { }
+        New-Item -ItemType Directory -Path $script:TestDataDir -Force | Out-Null
+    }
+
+    It "uninstalls px when the marker exists" {
+        Set-Content -Path (Get-PxInstalledMarkerPath) -Value 'x'
+        Mock Test-PxInstalled { $true }
+        Remove-PxProxy
+        Should -Invoke Invoke-CommandLine -Times 1 -ParameterFilter { $CommandLine -eq 'scoop uninstall px' }
+        Test-Path (Get-PxInstalledMarkerPath) | Should -BeFalse
+    }
+
+    It "does not uninstall px when no marker exists" {
+        Remove-Item (Get-PxInstalledMarkerPath) -ErrorAction SilentlyContinue
+        Remove-PxProxy
+        Should -Invoke Invoke-CommandLine -Times 0
+    }
+
+    It "deletes the px config file" {
+        Set-Content -Path (Get-PxConfigPath) -Value 'stale'
+        Remove-PxProxy
+        Test-Path (Get-PxConfigPath) | Should -BeFalse
+    }
+}
+
+Describe "Invoke-PxProxy" {
+    It "dispatches install" {
+        Mock Install-PxProxy { }
+        Invoke-PxProxy -Action install
+        Should -Invoke Install-PxProxy -Times 1
+    }
+
+    It "dispatches start with the ProxyHost override" {
+        Mock Start-PxProxy { }
+        Invoke-PxProxy -Action start -ProxyHost 'x.corp:8080'
+        Should -Invoke Start-PxProxy -Times 1 -ParameterFilter { $ProxyHost -eq 'x.corp:8080' }
+    }
+
+    It "dispatches stop" {
+        Mock Stop-PxProxy { }
+        Invoke-PxProxy -Action stop
+        Should -Invoke Stop-PxProxy -Times 1
+    }
+
+    It "dispatches test" {
+        Mock Test-PxProxy { $true }
+        Invoke-PxProxy -Action test
+        Should -Invoke Test-PxProxy -Times 1
+    }
+
+    It "dispatches remove" {
+        Mock Remove-PxProxy { }
+        Invoke-PxProxy -Action remove
+        Should -Invoke Remove-PxProxy -Times 1
+    }
+}

--- a/tools/proxy/px-proxy.Tests.ps1
+++ b/tools/proxy/px-proxy.Tests.ps1
@@ -72,6 +72,45 @@ Describe "Get-PxExecutable" {
         Mock Get-Command { $null }
         Get-PxExecutable | Should -BeNullOrEmpty
     }
+
+    It "uses the pxw.exe sitting next to px when the shim is missing" {
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'pxw' }
+        Mock Get-Command { [pscustomobject]@{ Source = 'C:\scoop\apps\px\current\px.exe' } } -ParameterFilter { $Name -eq 'px' }
+        Mock Test-Path { $true }
+        Get-PxExecutable -Windowless | Should -Be 'C:\scoop\apps\px\current\pxw.exe'
+    }
+}
+
+Describe "Test-PxRunning" {
+    It "returns true when a px process is present" {
+        Mock Get-Process { @([pscustomobject]@{ Id = 42 }) }
+        Test-PxRunning | Should -BeTrue
+    }
+
+    It "returns false when no px process is present" {
+        Mock Get-Process { $null }
+        Test-PxRunning | Should -BeFalse
+    }
+}
+
+Describe "Get-KlistOutput" {
+    It "returns the output of the klist command" {
+        Mock klist { 'Cached Tickets: (0)' }
+        Get-KlistOutput | Should -Be 'Cached Tickets: (0)'
+    }
+}
+
+Describe "Library-mode env restoration" {
+    It "restores a pre-existing SETPROXY_LIBRARY_MODE after dot-sourcing setProxy" {
+        $env:SETPROXY_LIBRARY_MODE = 'preset'
+        try {
+            . "$PSScriptRoot\px-proxy.ps1"
+            $env:SETPROXY_LIBRARY_MODE | Should -Be 'preset'
+        }
+        finally {
+            Remove-Item Env:\SETPROXY_LIBRARY_MODE -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 Describe "Get-KerberosProxyHost" {
@@ -108,6 +147,11 @@ Describe "Get-KerberosProxyHost" {
         Get-KerberosProxyHost | Out-Null
         Should -Invoke Write-Warning -Times 0
     }
+
+    It "returns null when klist is unavailable and throws" {
+        Mock Get-KlistOutput { throw 'klist: command not found' }
+        Get-KerberosProxyHost | Should -BeNullOrEmpty
+    }
 }
 
 Describe "Resolve-PxUpstreamProxy" {
@@ -133,6 +177,30 @@ Describe "Resolve-PxUpstreamProxy" {
         Mock Get-KerberosProxyHost { $null }
         Mock Test-RunningInCIorTestEnvironment { $true }
         { Resolve-PxUpstreamProxy } | Should -Throw
+    }
+
+    It "prompts for the host in an interactive session when nothing resolves" {
+        Mock Get-InternetSettingsFromRegistry { $null }
+        Mock Get-KerberosProxyHost { $null }
+        Mock Test-RunningInCIorTestEnvironment { $false }
+        Mock Read-Host { 'typed.corp:8080' }
+        Resolve-PxUpstreamProxy | Should -Be 'typed.corp:8080'
+        Should -Invoke Read-Host -Times 1
+    }
+
+    It "throws when the interactive prompt is answered with nothing" {
+        Mock Get-InternetSettingsFromRegistry { $null }
+        Mock Get-KerberosProxyHost { $null }
+        Mock Test-RunningInCIorTestEnvironment { $false }
+        Mock Read-Host { '   ' }
+        { Resolve-PxUpstreamProxy } | Should -Throw
+    }
+
+    It "ignores a PAC result that reports DIRECT" {
+        Mock Get-InternetSettingsFromRegistry { @{ AutoConfigUrl = 'http://wpad/pac' } }
+        Mock Get-ProxyFromPac { @{ ProxyUrl = $null; IsDirect = $true } }
+        Mock Get-KerberosProxyHost { 'spn.corp:8080' }
+        Resolve-PxUpstreamProxy | Should -Be 'spn.corp:8080'
     }
 }
 
@@ -264,6 +332,59 @@ Describe "Test-PxProxy" {
     It "returns false on a generic error" {
         Mock Invoke-WebRequest { throw 'connection refused' }
         Test-PxProxy -WarningAction SilentlyContinue | Should -BeFalse
+    }
+
+    It "reports a revocation failure as its own diagnostic" {
+        Mock Invoke-WebRequest { throw 'The revocation function was unable to check revocation for the certificate.' }
+        Mock Write-Warning { }
+        Test-PxProxy | Should -BeFalse
+        Should -Invoke Write-Warning -Times 1 -ParameterFilter { $Message -match 'revocation check failed' }
+    }
+
+    It "reports a certificate error distinctly from a revocation failure" {
+        Mock Invoke-WebRequest { throw 'The remote certificate is invalid according to the validation procedure.' }
+        Mock Write-Warning { }
+        Test-PxProxy | Should -BeFalse
+        Should -Invoke Write-Warning -Times 1 -ParameterFilter { $Message -match 'TLS/certificate error' }
+    }
+}
+
+Describe "Script entry point" {
+    # Invokes the script as a program (library mode off) so the guard's
+    # 'exit (Invoke-PxProxyMain ...)' runs. Invoked with '&', so exit returns
+    # control here and sets $LASTEXITCODE rather than killing the test host.
+    # 'stop' is the only action that is a pure no-op when px is not running;
+    # skipped outright if px happens to be running, so the test never stops a
+    # developer's live px.
+    It "dispatches the action and exits 0 when not in library mode" -Skip:([bool](Get-Process -Name 'px', 'pxw' -ErrorAction SilentlyContinue)) {
+        Remove-Item Env:\PXPROXY_LIBRARY_MODE -ErrorAction SilentlyContinue
+        try {
+            & "$PSScriptRoot\px-proxy.ps1" stop *> $null
+            $LASTEXITCODE | Should -Be 0
+        }
+        finally {
+            $env:PXPROXY_LIBRARY_MODE = '1'
+        }
+    }
+}
+
+Describe "Invoke-PxProxyMain" {
+    It "returns 0 when the action succeeds" {
+        Mock Invoke-PxProxy { }
+        Invoke-PxProxyMain -Action stop | Should -Be 0
+    }
+
+    It "returns 1 and reports the failure when the action throws" {
+        Mock Invoke-PxProxy { throw 'boom' }
+        Mock Write-Error { }
+        Invoke-PxProxyMain -Action start | Should -Be 1
+        Should -Invoke Write-Error -Times 1 -ParameterFilter { $Message -match "px-proxy 'start' failed: boom" }
+    }
+
+    It "passes the ProxyHost override through to the dispatcher" {
+        Mock Invoke-PxProxy { }
+        Invoke-PxProxyMain -Action start -ProxyHost 'x.corp:8080' | Should -Be 0
+        Should -Invoke Invoke-PxProxy -Times 1 -ParameterFilter { $ProxyHost -eq 'x.corp:8080' }
     }
 }
 

--- a/tools/proxy/px-proxy.Tests.ps1
+++ b/tools/proxy/px-proxy.Tests.ps1
@@ -80,7 +80,7 @@ Describe "Get-KerberosProxyHost" {
                 'Cached Tickets: (5)',
                 '    Server: HTTP/osproxy.corp.example @ CORP.EXAMPLE'
             ) }
-        Get-KerberosProxyHost | Should -Be 'osproxy.corp.example:8080'
+        Get-KerberosProxyHost -WarningAction SilentlyContinue | Should -Be 'osproxy.corp.example:8080'
     }
 
     It "returns null when no HTTP SPN is present" {
@@ -91,6 +91,22 @@ Describe "Get-KerberosProxyHost" {
     It "returns null when klist output is empty" {
         Mock Get-KlistOutput { $null }
         Get-KerberosProxyHost | Should -BeNullOrEmpty
+    }
+
+    It "warns that the host and port are a guess when it falls back to an SPN" {
+        Mock Get-KlistOutput { @('    Server: HTTP/intranet.corp.example @ CORP.EXAMPLE') }
+        Mock Write-Warning { }
+        Get-KerberosProxyHost | Out-Null
+        Should -Invoke Write-Warning -Times 1 -ParameterFilter {
+            $Message -match 'intranet\.corp\.example:8080' -and $Message -match '-ProxyHost'
+        }
+    }
+
+    It "does not warn when no SPN is found" {
+        Mock Get-KlistOutput { @('    Server: krbtgt/CORP.EXAMPLE') }
+        Mock Write-Warning { }
+        Get-KerberosProxyHost | Out-Null
+        Should -Invoke Write-Warning -Times 0
     }
 }
 
@@ -218,6 +234,15 @@ Describe "Start-PxProxy" {
         Mock Get-PxExecutable { $null }
         { Start-PxProxy } | Should -Throw
     }
+
+    It "fails fast without resolving the proxy or writing config when px is absent" {
+        Mock Get-PxExecutable { $null }
+        Mock Write-PxConfig { }
+        { Start-PxProxy } | Should -Throw
+        Should -Invoke Resolve-PxUpstreamProxy -Times 0
+        Should -Invoke Write-PxConfig -Times 0
+        Should -Invoke Start-Process -Times 0
+    }
 }
 
 Describe "Test-PxProxy" {
@@ -264,6 +289,14 @@ Describe "Remove-PxProxy" {
         Should -Invoke Invoke-CommandLine -Times 0
     }
 
+    It "keeps the marker when the uninstall is skipped because px is not on PATH" {
+        Set-Content -Path (Get-PxInstalledMarkerPath) -Value 'x'
+        Mock Test-PxInstalled { $false }
+        Remove-PxProxy
+        Should -Invoke Invoke-CommandLine -Times 0
+        Test-Path (Get-PxInstalledMarkerPath) | Should -BeTrue
+    }
+
     It "deletes the px config file" {
         Set-Content -Path (Get-PxConfigPath) -Value 'stale'
         Remove-PxProxy
@@ -294,6 +327,16 @@ Describe "Invoke-PxProxy" {
         Mock Test-PxProxy { $true }
         Invoke-PxProxy -Action test
         Should -Invoke Test-PxProxy -Times 1
+    }
+
+    It "throws when the test action fails, so the caller sees a non-zero exit code" {
+        Mock Test-PxProxy { $false }
+        { Invoke-PxProxy -Action test } | Should -Throw
+    }
+
+    It "does not throw when the test action succeeds" {
+        Mock Test-PxProxy { $true }
+        { Invoke-PxProxy -Action test } | Should -Not -Throw
     }
 
     It "dispatches remove" {

--- a/tools/proxy/px-proxy.bat
+++ b/tools/proxy/px-proxy.bat
@@ -1,0 +1,2 @@
+@echo off
+pwsh -ExecutionPolicy Bypass -File "%~dp0px-proxy.ps1" %* || exit /b 1

--- a/tools/proxy/px-proxy.ps1
+++ b/tools/proxy/px-proxy.ps1
@@ -1,0 +1,546 @@
+﻿#Requires -Version 7.4
+
+<#
+.SYNOPSIS
+    Manage a local px authenticating proxy for Windows and WSL.
+
+.DESCRIPTION
+    px authenticates to a corporate upstream proxy using the current Windows
+    logon session (SSPI: NTLM or Negotiate/Kerberos) and exposes a plain local
+    proxy on http://127.0.0.1:3128. Native CLI tools (git, pip, node, curl,
+    Claude Code) and WSL distros (mirrored networking) point at that endpoint
+    and reach the internet with no credentials stored anywhere.
+
+    Actions:
+      install  Install px via Scoop (only if not already present) and create
+               the px data directory. Does NOT resolve the proxy or write config.
+      start    Resolve the upstream proxy fresh, (re)write the px config, and
+               (re)start px so the running instance always reflects the current
+               network. Exactly one px instance results.
+      stop     Stop any running px cleanly.
+      test     Send an HTTPS request through the local px endpoint and report a
+               clear diagnostic (auth vs TLS/cert vs revocation).
+      remove   Stop px, uninstall it (only if this tool installed it), and delete
+               the px config and log files.
+
+.PARAMETER Action
+    One of: install, start, stop, test, remove. Defaults to 'start'.
+
+.PARAMETER ProxyHost
+    Optional manual upstream proxy 'host:port'. When provided, overrides
+    PAC/klist discovery for the 'start' action.
+
+.EXAMPLE
+    .\px-proxy.ps1 install
+
+.EXAMPLE
+    .\px-proxy.ps1 start
+
+.EXAMPLE
+    .\px-proxy.ps1 test
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false, Position = 0)]
+    [ValidateSet('install', 'start', 'stop', 'test', 'remove')]
+    [string]$Action = 'start',
+
+    [Parameter(Mandatory = $false)]
+    [string]$ProxyHost
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$InformationPreference = 'Continue'
+
+# --- Dependencies ---------------------------------------------------------
+. "$PSScriptRoot\..\..\lib\utils\utils.ps1"
+
+# Source setProxy.ps1 in library mode to reuse its PAC-resolution helpers
+# (Get-InternetSettingsFromRegistry, Get-ProxyFromPac) without executing main.
+$script:PreviousSetProxyLibMode = $env:SETPROXY_LIBRARY_MODE
+$env:SETPROXY_LIBRARY_MODE = '1'
+try {
+    . "$PSScriptRoot\setProxy.ps1"
+}
+finally {
+    if ($null -eq $script:PreviousSetProxyLibMode) {
+        Remove-Item Env:\SETPROXY_LIBRARY_MODE -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:SETPROXY_LIBRARY_MODE = $script:PreviousSetProxyLibMode
+    }
+}
+
+# --- Constants ------------------------------------------------------------
+$script:PxListen = '127.0.0.1'
+$script:PxPort = 3128
+$script:PxEndpoint = "http://127.0.0.1:3128"
+$script:PxDefaultUpstreamPort = 8080
+$script:PxInstalledMarkerName = 'installed-by-px-proxy.marker'
+
+# --- Path helpers ---------------------------------------------------------
+function Get-PxDataDir {
+    <#
+    .SYNOPSIS
+        Returns the px data directory (config and logs), creating nothing.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    return (Join-Path $env:USERPROFILE '.config\px')
+}
+
+function Get-PxConfigPath {
+    <#
+    .SYNOPSIS
+        Returns the full path to the px config file (px.ini).
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    return (Join-Path (Get-PxDataDir) 'px.ini')
+}
+
+function Get-PxInstalledMarkerPath {
+    <#
+    .SYNOPSIS
+        Returns the path to the marker written when this tool installed px.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    return (Join-Path (Get-PxDataDir) $script:PxInstalledMarkerName)
+}
+
+# --- px discovery ---------------------------------------------------------
+function Test-PxInstalled {
+    <#
+    .SYNOPSIS
+        Returns $true when a px executable is available (Scoop shim or pipx).
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    return [bool](Get-Command 'px' -ErrorAction SilentlyContinue)
+}
+
+function Get-PxExecutable {
+    <#
+    .SYNOPSIS
+        Resolves the px (or windowless pxw) executable path.
+
+    .PARAMETER Windowless
+        Prefer the windowless 'pxw' variant (no console window).
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [switch]$Windowless
+    )
+
+    $name = if ($Windowless) { 'pxw' } else { 'px' }
+
+    $cmd = Get-Command $name -ErrorAction SilentlyContinue
+    if ($cmd) {
+        return $cmd.Source
+    }
+
+    # Fallback: look for the requested variant next to px, else use px itself.
+    $px = Get-Command 'px' -ErrorAction SilentlyContinue
+    if ($px) {
+        $candidate = Join-Path (Split-Path $px.Source -Parent) "$name.exe"
+        if (Test-Path $candidate) {
+            return $candidate
+        }
+        return $px.Source
+    }
+
+    return $null
+}
+
+function Test-PxRunning {
+    <#
+    .SYNOPSIS
+        Returns $true when a px or pxw process is currently running.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    $procs = Get-Process -Name 'px', 'pxw' -ErrorAction SilentlyContinue
+    return [bool]$procs
+}
+
+# --- Upstream proxy resolution -------------------------------------------
+function Get-KlistOutput {
+    <#
+    .SYNOPSIS
+        Thin wrapper around the external 'klist' command (mockable in tests).
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param()
+
+    return (klist 2>$null)
+}
+
+function Get-KerberosProxyHost {
+    <#
+    .SYNOPSIS
+        Extracts an 'HTTP/<host>' service-ticket host from klist output.
+
+    .DESCRIPTION
+        Returns '<host>:<default port>' when a Kerberos HTTP SPN is present in
+        the current logon session, otherwise $null. Used as a fallback when PAC
+        evaluation yields no proxy.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    $output = $null
+    try {
+        $output = Get-KlistOutput
+    }
+    catch {
+        return $null
+    }
+
+    if (-not $output) {
+        return $null
+    }
+
+    foreach ($line in $output) {
+        if ($line -match 'HTTP/(?<host>[A-Za-z0-9._-]+)') {
+            return ("{0}:{1}" -f $Matches['host'], $script:PxDefaultUpstreamPort)
+        }
+    }
+
+    return $null
+}
+
+function Resolve-PxUpstreamProxy {
+    <#
+    .SYNOPSIS
+        Resolves the real upstream proxy 'host:port' for px.
+
+    .DESCRIPTION
+        Resolution order:
+          1. Explicit -ProxyHost override.
+          2. PAC evaluation via setProxy.ps1's Get-ProxyFromPac (the real proxy
+             the PAC hands out, which carries the Kerberos SPN).
+          3. klist-derived HTTP/<host> SPN fallback.
+          4. Manual prompt (interactive sessions only).
+
+    .PARAMETER ProxyHost
+        Optional manual override.
+
+    .PARAMETER ProbeUrl
+        URL used to evaluate the PAC (default: https://www.google.com).
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$ProxyHost,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ProbeUrl = 'https://www.google.com'
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ProxyHost)) {
+        return $ProxyHost.Trim()
+    }
+
+    # 1. PAC evaluation (reuse setProxy.ps1 helpers)
+    $settings = Get-InternetSettingsFromRegistry
+    if ($settings) {
+        $pac = Get-ProxyFromPac -InternetSettings $settings -ProbeUrl $ProbeUrl
+        if ($pac -and $pac.ContainsKey('IsDirect') -and -not $pac.IsDirect -and $pac.ProxyUrl) {
+            $authority = ([Uri]$pac.ProxyUrl).Authority
+            if (-not [string]::IsNullOrWhiteSpace($authority)) {
+                Write-Information "Resolved upstream proxy via PAC: $authority"
+                return $authority
+            }
+        }
+    }
+
+    # 2. klist SPN fallback
+    $spnHost = Get-KerberosProxyHost
+    if ($spnHost) {
+        Write-Information "Resolved upstream proxy via Kerberos SPN (klist): $spnHost"
+        return $spnHost
+    }
+
+    # 3. Manual prompt (interactive only)
+    if (-not (Test-RunningInCIorTestEnvironment)) {
+        $manual = Read-Host "Could not auto-resolve the upstream proxy. Enter proxy host:port (e.g. proxy.corp:8080)"
+        if (-not [string]::IsNullOrWhiteSpace($manual)) {
+            return $manual.Trim()
+        }
+    }
+
+    throw "Could not resolve an upstream proxy host (PAC returned DIRECT/none, no Kerberos SPN found, no manual entry). Re-run with -ProxyHost '<host:port>'."
+}
+
+# --- px config ------------------------------------------------------------
+function Write-PxConfig {
+    <#
+    .SYNOPSIS
+        (Re)writes the px config from the resolved upstream proxy.
+
+    .DESCRIPTION
+        Overwrites px.ini every call. Enables logging (log = 3: unique
+        debug-<pid>.log in px's working directory, which start sets to the px
+        data directory).
+
+    .PARAMETER UpstreamProxy
+        The upstream proxy 'host:port' px authenticates to.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$UpstreamProxy
+    )
+
+    $dir = Get-PxDataDir
+    New-Directory -Path $dir
+
+    $configPath = Get-PxConfigPath
+
+    $content = @"
+[proxy]
+server = $UpstreamProxy
+listen = $script:PxListen
+port = $script:PxPort
+auth =
+
+[settings]
+log = 3
+"@
+
+    if ($PSCmdlet.ShouldProcess($configPath, "Write px config")) {
+        Set-Content -Path $configPath -Value $content -Encoding ascii
+    }
+
+    return $configPath
+}
+
+# --- Actions --------------------------------------------------------------
+function Install-PxProxy {
+    <#
+    .SYNOPSIS
+        Installs px via Scoop when absent and ensures the data directory exists.
+    #>
+    [CmdletBinding()]
+    param()
+
+    New-Directory -Path (Get-PxDataDir)
+
+    if (Test-PxInstalled) {
+        Write-Information "px is already installed; skipping Scoop install."
+        return
+    }
+
+    Write-Information "Installing px via Scoop ..."
+    Invoke-CommandLine -CommandLine 'scoop install px' -StopAtError $true
+    Set-Content -Path (Get-PxInstalledMarkerPath) -Value (Get-Date -Format 'o') -Encoding ascii
+    Write-Information "px installed."
+}
+
+function Stop-PxProxy {
+    <#
+    .SYNOPSIS
+        Stops any running px instance cleanly.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
+
+    if (-not (Test-PxRunning)) {
+        Write-Information "px is not running."
+        return
+    }
+
+    if (-not $PSCmdlet.ShouldProcess('px', 'Stop running px instance')) {
+        return
+    }
+
+    $px = Get-PxExecutable
+    if ($px) {
+        Invoke-CommandLine -CommandLine "& `"$px`" --quit" -StopAtError $false -PrintCommand $false
+    }
+
+    Start-Sleep -Milliseconds 300
+
+    if (Test-PxRunning) {
+        Get-Process -Name 'px', 'pxw' -ErrorAction SilentlyContinue |
+            ForEach-Object { Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }
+    }
+
+    Write-Information "px stopped."
+}
+
+function Start-PxProxy {
+    <#
+    .SYNOPSIS
+        Resolves the proxy, rewrites config, and (re)starts px.
+
+    .PARAMETER ProxyHost
+        Optional manual upstream 'host:port' override.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$ProxyHost
+    )
+
+    $upstream = Resolve-PxUpstreamProxy -ProxyHost $ProxyHost
+
+    if (-not $PSCmdlet.ShouldProcess("px ($upstream)", 'Rewrite config and restart px')) {
+        return
+    }
+
+    $configPath = Write-PxConfig -UpstreamProxy $upstream
+
+    # Always restart so the running instance reflects the fresh config.
+    if (Test-PxRunning) {
+        Stop-PxProxy
+    }
+
+    $exe = Get-PxExecutable -Windowless
+    if (-not $exe) {
+        throw "px executable not found. Run 'px-proxy install' first."
+    }
+
+    $dir = Get-PxDataDir
+    Start-Process -FilePath $exe -ArgumentList "--config=`"$configPath`"" -WorkingDirectory $dir -WindowStyle Hidden | Out-Null
+
+    Write-Information "px started (upstream $upstream). Listening on $script:PxEndpoint. Log: $dir\debug-*.log"
+}
+
+function Test-PxProxy {
+    <#
+    .SYNOPSIS
+        Sends an HTTPS request through the local px endpoint and diagnoses.
+
+    .PARAMETER Url
+        HTTPS URL to probe (default: https://www.google.com).
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$Url = 'https://www.google.com'
+    )
+
+    $logHint = "px log: $(Get-PxDataDir)\debug-*.log"
+
+    try {
+        $response = Invoke-WebRequest -Uri $Url -Proxy $script:PxEndpoint -UseBasicParsing -TimeoutSec 20
+        Write-Information "SUCCESS: $Url returned HTTP $($response.StatusCode) via $script:PxEndpoint. No credentials were entered."
+        return $true
+    }
+    catch {
+        $message = $_.Exception.Message
+        $status = $null
+        if (($_.Exception.PSObject.Properties.Name -contains 'Response') -and $_.Exception.Response) {
+            try { $status = [int]$_.Exception.Response.StatusCode } catch { $status = $null }
+        }
+
+        if ($status -eq 407) {
+            Write-Warning "FAILED (407 Proxy Authentication Required): px could not authenticate to the upstream proxy. Confirm the resolved proxy host carries a Kerberos SPN (klist should list HTTP/<host>). $logHint"
+        }
+        elseif ($message -match 'revocation|revoc|CRL') {
+            Write-Warning "TLS revocation check failed: Schannel could not reach the certificate revocation endpoint. This is often benign behind TLS inspection (the 'curl --ssl-no-revoke' scenario). Ensure the corporate root CA is trusted. $logHint"
+        }
+        elseif ($message -match 'certificate|trust|SSL|TLS|cert') {
+            Write-Warning "TLS/certificate error: import the corporate root CA into the Windows trust store. $logHint"
+        }
+        else {
+            Write-Warning "FAILED: $message. Is px running? (px-proxy start). $logHint"
+        }
+
+        return $false
+    }
+}
+
+function Remove-PxProxy {
+    <#
+    .SYNOPSIS
+        Stops px, uninstalls it if this tool installed it, and deletes config/logs.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
+
+    if (-not $PSCmdlet.ShouldProcess('px', 'Stop, uninstall (if installed by this tool), and delete config/logs')) {
+        return
+    }
+
+    Stop-PxProxy
+
+    $marker = Get-PxInstalledMarkerPath
+    if (Test-Path $marker) {
+        if (Test-PxInstalled) {
+            Write-Information "Uninstalling px via Scoop ..."
+            Invoke-CommandLine -CommandLine 'scoop uninstall px' -StopAtError $false
+        }
+        Remove-Item $marker -ErrorAction SilentlyContinue
+    }
+
+    $configPath = Get-PxConfigPath
+    if (Test-Path $configPath) {
+        Remove-Item $configPath -ErrorAction SilentlyContinue
+    }
+
+    $dir = Get-PxDataDir
+    if (Test-Path $dir) {
+        Get-ChildItem -Path $dir -Filter 'debug-*.log' -ErrorAction SilentlyContinue |
+            Remove-Item -ErrorAction SilentlyContinue
+    }
+
+    Write-Information "px removed (config and logs deleted)."
+}
+
+function Invoke-PxProxy {
+    <#
+    .SYNOPSIS
+        Dispatches a px-proxy action.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('install', 'start', 'stop', 'test', 'remove')]
+        [string]$Action,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ProxyHost
+    )
+
+    switch ($Action) {
+        'install' { Install-PxProxy }
+        'start' { Start-PxProxy -ProxyHost $ProxyHost }
+        'stop' { Stop-PxProxy }
+        'test' { [void](Test-PxProxy) }
+        'remove' { Remove-PxProxy }
+    }
+}
+
+# --- Main -----------------------------------------------------------------
+if (-not $env:PXPROXY_LIBRARY_MODE) {
+    try {
+        Invoke-PxProxy -Action $Action -ProxyHost $ProxyHost
+    }
+    catch {
+        Write-Error "px-proxy '$Action' failed: $_"
+        exit 1
+    }
+}

--- a/tools/proxy/px-proxy.ps1
+++ b/tools/proxy/px-proxy.ps1
@@ -76,7 +76,7 @@ finally {
 # --- Constants ------------------------------------------------------------
 $script:PxListen = '127.0.0.1'
 $script:PxPort = 3128
-$script:PxEndpoint = "http://127.0.0.1:3128"
+$script:PxEndpoint = "http://${script:PxListen}:${script:PxPort}"
 $script:PxDefaultUpstreamPort = 8080
 $script:PxInstalledMarkerName = 'installed-by-px-proxy.marker'
 
@@ -219,7 +219,12 @@ function Get-KerberosProxyHost {
 
     foreach ($line in $output) {
         if ($line -match 'HTTP/(?<host>[A-Za-z0-9._-]+)') {
-            return ("{0}:{1}" -f $Matches['host'], $script:PxDefaultUpstreamPort)
+            $candidate = "{0}:{1}" -f $Matches['host'], $script:PxDefaultUpstreamPort
+            # The ticket cache holds an HTTP/ SPN for every intranet site this
+            # session has touched, not just the proxy. Take the first one, but
+            # never let the guess pass silently -- a wrong host surfaces as a 407.
+            Write-Warning "Guessing the upstream proxy is '$candidate': it is the first HTTP/ ticket in your klist cache and the port is a default. If requests fail, re-run with -ProxyHost '<host:port>'."
+            return $candidate
         }
     }
 
@@ -275,7 +280,6 @@ function Resolve-PxUpstreamProxy {
     # 2. klist SPN fallback
     $spnHost = Get-KerberosProxyHost
     if ($spnHost) {
-        Write-Information "Resolved upstream proxy via Kerberos SPN (klist): $spnHost"
         return $spnHost
     }
 
@@ -403,6 +407,12 @@ function Start-PxProxy {
         [string]$ProxyHost
     )
 
+    # Fail before resolving (which may prompt) or writing a config we cannot use.
+    $exe = Get-PxExecutable -Windowless
+    if (-not $exe) {
+        throw "px executable not found. Run 'px-proxy install' first."
+    }
+
     $upstream = Resolve-PxUpstreamProxy -ProxyHost $ProxyHost
 
     if (-not $PSCmdlet.ShouldProcess("px ($upstream)", 'Rewrite config and restart px')) {
@@ -414,11 +424,6 @@ function Start-PxProxy {
     # Always restart so the running instance reflects the fresh config.
     if (Test-PxRunning) {
         Stop-PxProxy
-    }
-
-    $exe = Get-PxExecutable -Windowless
-    if (-not $exe) {
-        throw "px executable not found. Run 'px-proxy install' first."
     }
 
     $dir = Get-PxDataDir
@@ -492,8 +497,13 @@ function Remove-PxProxy {
         if (Test-PxInstalled) {
             Write-Information "Uninstalling px via Scoop ..."
             Invoke-CommandLine -CommandLine 'scoop uninstall px' -StopAtError $false
+            # Keep the marker unless the uninstall actually ran, so a later
+            # 'remove' from a shell with px on PATH can still clean it up.
+            Remove-Item $marker -ErrorAction SilentlyContinue
         }
-        Remove-Item $marker -ErrorAction SilentlyContinue
+        else {
+            Write-Warning "px is not on PATH, so it was not uninstalled. Keeping the install marker at '$marker'; re-run 'px-proxy remove' from a shell where 'px' resolves."
+        }
     }
 
     $configPath = Get-PxConfigPath
@@ -529,7 +539,11 @@ function Invoke-PxProxy {
         'install' { Install-PxProxy }
         'start' { Start-PxProxy -ProxyHost $ProxyHost }
         'stop' { Stop-PxProxy }
-        'test' { [void](Test-PxProxy) }
+        'test' {
+            if (-not (Test-PxProxy)) {
+                throw "the HTTPS probe through $script:PxEndpoint did not succeed (see the warning above)."
+            }
+        }
         'remove' { Remove-PxProxy }
     }
 }
@@ -540,7 +554,9 @@ if (-not $env:PXPROXY_LIBRARY_MODE) {
         Invoke-PxProxy -Action $Action -ProxyHost $ProxyHost
     }
     catch {
-        Write-Error "px-proxy '$Action' failed: $_"
+        # -ErrorAction Continue: the script sets $ErrorActionPreference = 'Stop',
+        # which would otherwise make Write-Error terminating and skip the exit.
+        Write-Error "px-proxy '$Action' failed: $_" -ErrorAction Continue
         exit 1
     }
 }

--- a/tools/proxy/px-proxy.ps1
+++ b/tools/proxy/px-proxy.ps1
@@ -548,15 +548,43 @@ function Invoke-PxProxy {
     }
 }
 
-# --- Main -----------------------------------------------------------------
-if (-not $env:PXPROXY_LIBRARY_MODE) {
+function Invoke-PxProxyMain {
+    <#
+    .SYNOPSIS
+        Runs an action and maps the outcome to a process exit code.
+
+    .DESCRIPTION
+        Split from the entry-point guard so the error handling is reachable from
+        tests: the guard itself can only ever run when the script is invoked as a
+        program, never when it is dot-sourced.
+
+    .OUTPUTS
+        0 on success, 1 on failure.
+    #>
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('install', 'start', 'stop', 'test', 'remove')]
+        [string]$Action,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ProxyHost
+    )
+
     try {
         Invoke-PxProxy -Action $Action -ProxyHost $ProxyHost
+        return 0
     }
     catch {
         # -ErrorAction Continue: the script sets $ErrorActionPreference = 'Stop',
         # which would otherwise make Write-Error terminating and skip the exit.
         Write-Error "px-proxy '$Action' failed: $_" -ErrorAction Continue
-        exit 1
+        return 1
     }
+}
+
+# --- Main -----------------------------------------------------------------
+if (-not $env:PXPROXY_LIBRARY_MODE) {
+    exit (Invoke-PxProxyMain -Action $Action -ProxyHost $ProxyHost)
 }

--- a/tools/proxy/setProxy.Tests.ps1
+++ b/tools/proxy/setProxy.Tests.ps1
@@ -383,6 +383,12 @@ Describe "Initialize-ProxyConfiguration" {
         [System.Net.WebRequest]::DefaultWebProxy = $script:SavedWebProxy
     }
 
+    BeforeEach {
+        # Default: no px running, so tests exercise the PAC/fallback path
+        # deterministically regardless of the host environment.
+        Mock Test-PxProxyAvailable { $false }
+    }
+
     Context "When PAC is configured and proxy is resolved" {
         It "Should initialize with system proxy and set environment variables" {
             Mock Get-InternetSettingsFromRegistry {
@@ -567,6 +573,193 @@ Describe "Initialize-ProxyConfiguration" {
             # This will pass if either PAC is configured (proxy set) or fallback is used
             $Env:HTTP_PROXY | Should -Not -BeNullOrEmpty
         }
+    }
+}
+
+Describe "Initialize-ProxyConfiguration -UsePx" {
+    BeforeAll {
+        # Save original environment and proxy state
+        $script:PxSavedHttpProxy = $Env:HTTP_PROXY
+        $script:PxSavedHttpsProxy = $Env:HTTPS_PROXY
+        $script:PxSavedNoProxy = $Env:NO_PROXY
+        $script:PxSavedWebProxy = [System.Net.WebRequest]::DefaultWebProxy
+    }
+
+    AfterEach {
+        # Clean up environment variables and proxy state after each test
+        if ($null -eq $script:PxSavedHttpProxy) {
+            Remove-Item Env:\HTTP_PROXY -ErrorAction SilentlyContinue
+        } else {
+            $Env:HTTP_PROXY = $script:PxSavedHttpProxy
+        }
+
+        if ($null -eq $script:PxSavedHttpsProxy) {
+            Remove-Item Env:\HTTPS_PROXY -ErrorAction SilentlyContinue
+        } else {
+            $Env:HTTPS_PROXY = $script:PxSavedHttpsProxy
+        }
+
+        if ($null -eq $script:PxSavedNoProxy) {
+            Remove-Item Env:\NO_PROXY -ErrorAction SilentlyContinue
+        } else {
+            $Env:NO_PROXY = $script:PxSavedNoProxy
+        }
+
+        [System.Net.WebRequest]::DefaultWebProxy = $script:PxSavedWebProxy
+    }
+
+    BeforeEach {
+        # Default: no px auto-detected. Individual tests override as needed;
+        # -UsePx still forces px regardless of this probe result.
+        Mock Test-PxProxyAvailable { $false }
+    }
+
+    Context "When -UsePx is supplied" {
+        It "Should set HTTP_PROXY and HTTPS_PROXY to the default px endpoint" {
+            Initialize-ProxyConfiguration -UsePx
+
+            $Env:HTTP_PROXY | Should -Be "http://127.0.0.1:3128"
+            $Env:HTTPS_PROXY | Should -Be "http://127.0.0.1:3128"
+        }
+
+        It "Should set HTTP_PROXY and HTTPS_PROXY to a custom PxEndpoint" {
+            Initialize-ProxyConfiguration -UsePx -PxEndpoint "http://127.0.0.1:9999"
+
+            $Env:HTTP_PROXY | Should -Be "http://127.0.0.1:9999"
+            $Env:HTTPS_PROXY | Should -Be "http://127.0.0.1:9999"
+        }
+
+        It "Should set NO_PROXY to localhost" {
+            Initialize-ProxyConfiguration -UsePx
+
+            $Env:NO_PROXY | Should -Be "localhost"
+        }
+
+        It "Should set DefaultWebProxy to the px endpoint" {
+            Initialize-ProxyConfiguration -UsePx
+
+            $webProxy = [System.Net.WebRequest]::DefaultWebProxy
+            $webProxy | Should -Not -BeNullOrEmpty
+            $webProxy.Address.AbsoluteUri.TrimEnd('/') | Should -Be "http://127.0.0.1:3128"
+        }
+
+        It "Should NOT call PAC resolution functions" {
+            Mock Get-ProxyFromPac { }
+            Mock Get-InternetSettingsFromRegistry { }
+            Mock Set-ProxyEnvironment { }
+            Mock Initialize-DefaultWebProxy { }
+
+            Initialize-ProxyConfiguration -UsePx
+
+            Should -Invoke Get-ProxyFromPac -Times 0
+            Should -Invoke Get-InternetSettingsFromRegistry -Times 0
+            Should -Invoke Set-ProxyEnvironment -Times 0
+            Should -Invoke Initialize-DefaultWebProxy -Times 0
+        }
+
+        It "Should NOT prompt for credentials even when AskForCreds is set" {
+            Mock Get-ProxyCredentialsFromUser { return "user:pass@" }
+
+            Initialize-ProxyConfiguration -UsePx -AskForCreds
+
+            Should -Invoke Get-ProxyCredentialsFromUser -Times 0
+        }
+    }
+
+    Context "When -UsePx is NOT supplied" {
+        It "Should still take the existing PAC/fallback resolution path" {
+            Mock Get-InternetSettingsFromRegistry {
+                return [PSCustomObject]@{
+                    ProxyEnable = 1
+                }
+            }
+            Mock Enable-ProxyInRegistry { return $false }
+            Mock Set-NoProxyEnvironment { }
+            Mock Initialize-DefaultWebProxy { }
+            Mock Set-ProxyEnvironment { }
+
+            Initialize-ProxyConfiguration -ProbeUrl "https://www.microsoft.com" -FallbackProxyHost "some.fallback.de:8080"
+
+            Should -Invoke Get-InternetSettingsFromRegistry -Times 1
+            Should -Invoke Set-ProxyEnvironment -Times 1 -ParameterFilter { $UseFallback -eq $true }
+        }
+    }
+
+    Context "When px is auto-detected (no -UsePx/-NoPx)" {
+        It "Should target px automatically without touching PAC resolution" {
+            Mock Test-PxProxyAvailable { $true }
+            Mock Get-ProxyFromPac { }
+            Mock Get-InternetSettingsFromRegistry { }
+            Mock Set-ProxyEnvironment { }
+            Mock Initialize-DefaultWebProxy { }
+
+            Initialize-ProxyConfiguration -ProbeUrl "https://www.microsoft.com"
+
+            $Env:HTTP_PROXY | Should -Be "http://127.0.0.1:3128"
+            $Env:HTTPS_PROXY | Should -Be "http://127.0.0.1:3128"
+            Should -Invoke Get-ProxyFromPac -Times 0
+            Should -Invoke Set-ProxyEnvironment -Times 0
+        }
+
+        It "Should probe the custom PxEndpoint and target it when available" {
+            Mock Test-PxProxyAvailable { $true } -ParameterFilter { $PxEndpoint -eq "http://127.0.0.1:9999" }
+
+            Initialize-ProxyConfiguration -ProbeUrl "https://www.microsoft.com" -PxEndpoint "http://127.0.0.1:9999"
+
+            $Env:HTTP_PROXY | Should -Be "http://127.0.0.1:9999"
+            Should -Invoke Test-PxProxyAvailable -Times 1 -ParameterFilter { $PxEndpoint -eq "http://127.0.0.1:9999" }
+        }
+    }
+
+    Context "When px is running but -NoPx forces the corporate path" {
+        It "Should ignore px and take the PAC/fallback resolution path" {
+            Mock Test-PxProxyAvailable { $true }
+            Mock Get-InternetSettingsFromRegistry {
+                return [PSCustomObject]@{ ProxyEnable = 1 }
+            }
+            Mock Enable-ProxyInRegistry { return $false }
+            Mock Set-NoProxyEnvironment { }
+            Mock Initialize-DefaultWebProxy { }
+            Mock Set-ProxyEnvironment { }
+
+            Initialize-ProxyConfiguration -ProbeUrl "https://www.microsoft.com" -FallbackProxyHost "some.fallback.de:8080" -NoPx
+
+            $Env:HTTP_PROXY | Should -Not -Be "http://127.0.0.1:3128"
+            Should -Invoke Get-InternetSettingsFromRegistry -Times 1
+            Should -Invoke Set-ProxyEnvironment -Times 1
+        }
+    }
+
+    Context "When -UsePx is supplied and probe would be false" {
+        It "Should still target px without probing" {
+            Mock Test-PxProxyAvailable { $false }
+
+            Initialize-ProxyConfiguration -UsePx
+
+            $Env:HTTP_PROXY | Should -Be "http://127.0.0.1:3128"
+        }
+    }
+}
+
+Describe "Test-PxProxyAvailable" {
+    It "Should return false when nothing is listening on the endpoint" {
+        # Port 1 is not listening in the test environment
+        Test-PxProxyAvailable -PxEndpoint "http://127.0.0.1:1" -TimeoutMs 300 | Should -BeFalse
+    }
+
+    It "Should return true when a TCP listener answers on the endpoint" {
+        $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+        $listener.Start()
+        try {
+            $port = ([System.Net.IPEndPoint]$listener.LocalEndpoint).Port
+            Test-PxProxyAvailable -PxEndpoint "http://127.0.0.1:$port" -TimeoutMs 1000 | Should -BeTrue
+        } finally {
+            $listener.Stop()
+        }
+    }
+
+    It "Should return false for a malformed endpoint" {
+        Test-PxProxyAvailable -PxEndpoint "not-a-uri" -TimeoutMs 300 | Should -BeFalse
     }
 }
 

--- a/tools/proxy/setProxy.Tests.ps1
+++ b/tools/proxy/setProxy.Tests.ps1
@@ -741,6 +741,46 @@ Describe "Initialize-ProxyConfiguration -UsePx" {
     }
 }
 
+Describe "Script entry point" {
+    BeforeAll {
+        $script:EntrySavedHttpProxy = $Env:HTTP_PROXY
+        $script:EntrySavedHttpsProxy = $Env:HTTPS_PROXY
+        $script:EntrySavedNoProxy = $Env:NO_PROXY
+        $script:EntrySavedWebProxy = [System.Net.WebRequest]::DefaultWebProxy
+    }
+
+    AfterAll {
+        foreach ($pair in @(
+                @{ Name = 'HTTP_PROXY'; Value = $script:EntrySavedHttpProxy },
+                @{ Name = 'HTTPS_PROXY'; Value = $script:EntrySavedHttpsProxy },
+                @{ Name = 'NO_PROXY'; Value = $script:EntrySavedNoProxy })) {
+            if ($null -eq $pair.Value) {
+                Remove-Item "Env:\$($pair.Name)" -ErrorAction SilentlyContinue
+            } else {
+                Set-Item "Env:\$($pair.Name)" -Value $pair.Value
+            }
+        }
+        [System.Net.WebRequest]::DefaultWebProxy = $script:EntrySavedWebProxy
+        $env:SETPROXY_LIBRARY_MODE = '1'
+    }
+
+    # Runs the script as a program (library mode off) to prove the parameters
+    # declared in the Param() block reach Initialize-ProxyConfiguration. -UsePx
+    # is the one path that returns before any registry access, so this stays a
+    # side-effect-free unit test.
+    It "invokes the px path with -UsePx when not in library mode" {
+        Remove-Item Env:\SETPROXY_LIBRARY_MODE -ErrorAction SilentlyContinue
+        try {
+            & "$PSScriptRoot\setProxy.ps1" -UsePx -PxEndpoint "http://127.0.0.1:4242" | Out-Null
+            $Env:HTTP_PROXY | Should -Be "http://127.0.0.1:4242"
+            $Env:HTTPS_PROXY | Should -Be "http://127.0.0.1:4242"
+        }
+        finally {
+            $env:SETPROXY_LIBRARY_MODE = '1'
+        }
+    }
+}
+
 Describe "Test-PxProxyAvailable" {
     It "Should return false when nothing is listening on the endpoint" {
         # Port 1 is not listening in the test environment

--- a/tools/proxy/setProxy.ps1
+++ b/tools/proxy/setProxy.ps1
@@ -1,23 +1,40 @@
-<#
+﻿<#
 .SYNOPSIS
     Proxy settings for PowerShell using PAC resolution (no hardcoded proxy hosts)
 .DESCRIPTION
     Reads PAC/Internet Settings from the registry and uses the system web proxy
     to determine the effective proxy. Sets PowerShell's default proxy and common
     environment variables for tools (git, Python, etc.).
+
+    If a local px proxy is detected running on its endpoint, setProxy targets it
+    automatically (px handles corporate authentication); pass -NoPx to force the
+    corporate proxy, or -UsePx to always target px.
 .PARAMETER ProbeUrl
     URL to probe for proxy resolution (default: https://www.microsoft.com)
 .PARAMETER FallbackProxyHost
     Fallback proxy host:port when PAC resolution fails or is not configured (default: some.fallback.de:8080)
+.PARAMETER UsePx
+    Always targets a local px proxy endpoint instead of resolving/using the corporate proxy.
+    Use this when running px as a local authenticating proxy (see px-proxy.ps1).
+.PARAMETER NoPx
+    Forces the corporate-proxy path even when a running px is auto-detected.
+.PARAMETER PxEndpoint
+    The local px proxy endpoint to target/probe (default: http://127.0.0.1:3128)
 .EXAMPLE
     .\setProxy.ps1
-    Uses default probe URL and fallback proxy
+    Auto-detects a running px and targets it; otherwise resolves the corporate proxy
 .EXAMPLE
     .\setProxy.ps1 -FallbackProxyHost "corporate.proxy.com:8080"
     Uses custom fallback proxy for corporate environment
 .EXAMPLE
     .\setProxy.ps1 -askForCreds
     Prompts for credentials and embeds them in proxy environment variables (WARNING: Security risk!)
+.EXAMPLE
+    .\setProxy.ps1 -UsePx
+    Always targets the local px proxy endpoint (http://127.0.0.1:3128) instead of the corporate proxy
+.EXAMPLE
+    .\setProxy.ps1 -NoPx
+    Ignores any running px and forces the corporate-proxy resolution path
 #>
 
 Param(
@@ -28,7 +45,16 @@ Param(
     [string]$FallbackProxyHost = "some.fallback.de:8080",
 
     [Parameter(Mandatory = $false)]
-    [switch]$askForCreds
+    [switch]$askForCreds,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$UsePx,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$NoPx,
+
+    [Parameter(Mandatory = $false)]
+    [string]$PxEndpoint = "http://127.0.0.1:3128"
 )
 
 $InformationPreference = "Continue"
@@ -356,6 +382,52 @@ function Initialize-DefaultWebProxy {
     [System.Net.WebRequest]::DefaultWebProxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
 }
 
+function Test-PxProxyAvailable {
+    <#
+    .SYNOPSIS
+        Returns $true when a TCP listener answers at the px proxy endpoint.
+
+    .DESCRIPTION
+        Performs a short, decoupled TCP connect to the host:port parsed from the
+        px endpoint. Used to auto-detect a running px so setProxy can target it
+        without requiring the explicit -UsePx switch.
+
+    .PARAMETER PxEndpoint
+        The px proxy endpoint to probe (e.g. http://127.0.0.1:3128).
+
+    .PARAMETER TimeoutMs
+        Connect timeout in milliseconds (default: 500).
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$PxEndpoint = "http://127.0.0.1:3128",
+
+        [Parameter(Mandatory = $false)]
+        [int]$TimeoutMs = 500
+    )
+
+    $client = $null
+    try {
+        $uri = [Uri]$PxEndpoint
+        $client = [System.Net.Sockets.TcpClient]::new()
+        $asyncResult = $client.BeginConnect($uri.Host, $uri.Port, $null, $null)
+        $connected = $asyncResult.AsyncWaitHandle.WaitOne($TimeoutMs)
+        if ($connected -and $client.Connected) {
+            $client.EndConnect($asyncResult)
+            return $true
+        }
+        return $false
+    } catch {
+        return $false
+    } finally {
+        if ($client) {
+            $client.Close()
+        }
+    }
+}
+
 <#
 .SYNOPSIS
     Main orchestration function for proxy configuration
@@ -367,6 +439,12 @@ function Initialize-DefaultWebProxy {
     Fallback proxy host:port (uses script-level default if not provided)
 .PARAMETER AskForCreds
     If set, prompts user for credentials to embed in proxy environment variables
+.PARAMETER UsePx
+    If set, always targets the local px proxy endpoint instead of resolving/using the corporate proxy
+.PARAMETER NoPx
+    If set, forces the corporate-proxy path even when a running px is auto-detected
+.PARAMETER PxEndpoint
+    The local px proxy endpoint to target/probe (e.g., http://127.0.0.1:3128)
 #>
 function Initialize-ProxyConfiguration {
     [CmdletBinding()]
@@ -378,8 +456,49 @@ function Initialize-ProxyConfiguration {
         [string]$FallbackProxyHost,
 
         [Parameter(Mandatory = $false)]
-        [switch]$AskForCreds
+        [switch]$AskForCreds,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$UsePx,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$NoPx,
+
+        [Parameter(Mandatory = $false)]
+        [string]$PxEndpoint = "http://127.0.0.1:3128"
     )
+
+    # Decide whether to target a local px proxy. px is used when explicitly
+    # requested (-UsePx) or auto-detected as running, unless -NoPx forces the
+    # corporate-proxy path. px handles authentication itself, so no proxy
+    # credentials are configured in this branch.
+    $shouldUsePx = $false
+    if ($NoPx) {
+        $shouldUsePx = $false
+    } elseif ($UsePx) {
+        $shouldUsePx = $true
+    } elseif (Test-PxProxyAvailable -PxEndpoint $PxEndpoint) {
+        Write-Output "Detected running px proxy at $PxEndpoint; using it automatically (pass -NoPx to override)."
+        $shouldUsePx = $true
+    }
+
+    if ($shouldUsePx) {
+        Write-Output "Using local px proxy: $PxEndpoint"
+
+        $Env:HTTP_PROXY = $PxEndpoint
+        $Env:HTTPS_PROXY = $PxEndpoint
+
+        # Always set NO_PROXY
+        Set-NoProxyEnvironment
+
+        $noProxyList = if ($Env:NO_PROXY) { ($Env:NO_PROXY).Split(',') } else { @() }
+        [System.Net.WebRequest]::DefaultWebProxy = New-Object System.Net.WebProxy($PxEndpoint, $true, $noProxyList)
+
+        # Show summary
+        Write-Output "HTTP_PROXY/HTTPS_PROXY: $Env:HTTPS_PROXY"
+        Write-Output "NO_PROXY: $Env:NO_PROXY"
+        return
+    }
 
     # Get credentials if requested
     $credentialPrefix = ""
@@ -441,7 +560,7 @@ function Initialize-ProxyConfiguration {
 # Execute main logic unless in library mode (dot-sourced for function access only)
 # Set environment variable SETPROXY_LIBRARY_MODE=1 to expose functions without executing main logic
 if (-not $env:SETPROXY_LIBRARY_MODE) {
-    Initialize-ProxyConfiguration -ProbeUrl $ProbeUrl -FallbackProxyHost $FallbackProxyHost -AskForCreds:$askForCreds
+    Initialize-ProxyConfiguration -ProbeUrl $ProbeUrl -FallbackProxyHost $FallbackProxyHost -AskForCreds:$askForCreds -UsePx:$UsePx -NoPx:$NoPx -PxEndpoint $PxEndpoint
 }
 
 #endregion


### PR DESCRIPTION
## Summary

Implements **SC-040**: a Windows-side `px` authenticating proxy tool so native CLI tools (git, pip, node, curl, Claude Code) and WSL distros reach the internet through the corporate Kerberos/NTLM proxy with **no stored credentials**, using the current Windows logon session (SSPI).

`px-proxy.ps1` runs px as a local proxy on `http://127.0.0.1:3128`. `setProxy.ps1` gains an opt-in `-UsePx` switch to point the session at that endpoint.

## What is included

- `tools/proxy/px-proxy.ps1` - standalone tool with actions `install` / `start` / `stop` / `test` / `remove` (default `start`), plus a `-ProxyHost` override.
  - `install`: Scoop-installs px only if absent; creates the data dir; writes no config.
  - `start`: resolves the upstream proxy fresh (PAC via `setProxy.ps1`'s `Get-ProxyFromPac` -> klist `HTTP/<host>` SPN -> manual prompt), regenerates `px.ini`, and always restarts `pxw.exe` so exactly one instance reflects the current network.
  - `stop` / `test` / `remove` with clear 407 vs TLS vs revocation diagnostics.
  - Data dir: `%USERPROFILE%\.config\px`; logging enabled (`debug-<pid>.log`).
- `tools/proxy/px-proxy.bat` - Keypirinha-launchable wrapper.
- `tools/proxy/setProxy.ps1` - opt-in `-UsePx` / `-PxEndpoint`; default behavior unchanged.
- `tools/proxy/px-proxy.Tests.ps1` + `setProxy.Tests.ps1` - unit coverage of every action and success/failure branch.
- `docs/runbooks/px-proxy.md` - full runbook; `README.md` (More Features) and `docs/roadmap.md` reference the tool.

## Testing

- Targeted `px-proxy.Tests.ps1`: 36/36 pass (incl. PSScriptAnalyzer clean).
- `setProxy.Tests.ps1`: 62/62 pass.
- Full unit suite: 1025 pass. The 17 failures are the pre-existing environmental `lib/wsl/user` (14) and `lib/wsl/podman` (3) suites that execute against this machine's real Debian distro; none are in `tools/proxy`.

## Follow-up

The 8-step UAT procedure in `docs/backlog/sc-040.md` must be run on a corporate Windows machine; SC-040 stays In Progress until UAT passes.

_This PR also carries the earlier SC-041 commit (move flow-launcher guide into `docs/runbooks/`)._