### PR TITLE
proxy: setup-proxy Enter=Auto, user-configurable px settings, and proxy/WSL doc sync (SC-045, SC-046)

### DIFF
--- a/docs/architecture/wsl-manager-c4.md
+++ b/docs/architecture/wsl-manager-c4.md
@@ -50,7 +50,7 @@ C4Container
 
     System_Boundary(wslManagerSystem, "WSL Manager System") {
         Container(entryPoint, "wsl-manager.ps1", "PowerShell Script", "CLI entry point; parses parameters and delegates to the manager orchestrator")
-        Container(tuiLayer, "TUI Layer (manager.ps1)", "PowerShell + PwshSpectreConsole", "Interactive menu with arrow-key navigation, rich tables, and confirmation dialogs; planned SC-016 modernization")
+        Container(tuiLayer, "TUI Layer (manager.ps1)", "PowerShell + PwshSpectreConsole", "Interactive menu with arrow-key navigation, rich tables, and confirmation dialogs; SC-016 modernization (menu and table shipped, distro picker and confirmations planned)")
         Container(dispatcher, "Command Dispatcher (commands.ps1)", "PowerShell Script", "Routes commands to action functions; contains all Invoke-* workflow handlers and distro selection logic")
         Container(wslLib, "WSL Library (lib/wsl/)", "PowerShell Modules", "Core WSL operations: distro lifecycle, exec, user, wsl.conf, Docker, Podman, DevPod, proxy")
         Container(bashScripts, "Bash Install Scripts", "Shell Scripts", "Executed inside WSL distros for Docker, Podman, DevPod installation, and proxy configuration")
@@ -87,10 +87,10 @@ C4Component
     title WSL Manager — Component Diagram (WSL Library)
 
     Container_Boundary(tuiContainer, "TUI Layer") {
-        Component(showMenu, "Show-WslMenu", "Planned SC-016", "Arrow-key menu using Read-SpectreSelection; replaces Read-Host letter input")
-        Component(showTable, "Show-WslDistroTable", "Planned SC-016", "Rich distro table using Format-SpectreTable with colored status columns")
-        Component(selectDistro, "Select-WslDistro", "Planned SC-016", "Distro picker using Read-SpectreSelection; replaces numbered Read-Host input")
-        Component(confirmAction, "Confirm-DestructiveAction", "Planned SC-016", "Read-SpectreConfirm for remove, terminate, shutdown operations")
+        Component(showMenu, "Show-WslMenu", "Shipped SC-016b", "Arrow-key menu using Read-SpectreSelection; replaces Read-Host letter input")
+        Component(showTable, "Show-WslDistroTable", "Shipped SC-016c", "Rich distro table using Format-SpectreTable with colored status columns")
+        Component(selectDistro, "Select-WslDistro", "Planned SC-016d", "Distro picker using Read-SpectreSelection; replaces numbered Read-Host input")
+        Component(confirmAction, "Confirm-DestructiveAction", "Planned SC-016e", "Read-SpectreConfirm for remove, terminate, shutdown operations")
     }
 
     Container_Boundary(dispatcherContainer, "Command Dispatcher (commands.ps1)") {
@@ -165,16 +165,16 @@ C4Component
 
 ## SC-016 Change Impact Summary
 
-The following table maps the planned SC-016 changes to the affected components:
+The following table maps the SC-016 changes to the affected components and their current status:
 
-| SC-016 Change | Current Implementation | Planned Implementation | Affected Components |
-|---|---|---|---|
-| Menu selection | `Read-Host` letter input | `Read-SpectreSelection` arrow-key navigation | `manager.ps1` → `Show-WslMenu` (new) |
-| Distro table | `Write-Host` with basic colors | `Format-SpectreTable` with borders and colored status | `commands.ps1` → `Show-WslDistroTable` (new) |
-| Distro picker | `Read-Host` numbered input | `Read-SpectreSelection` for distro lists | `commands.ps1` → `Select-WslDistro` (modified) |
-| Destructive confirmations | Implicit (no confirmation in TUI) | `Read-SpectreConfirm` for remove, terminate, shutdown | `commands.ps1` → `Confirm-DestructiveAction` (new) |
-| Status coloring | `Write-Host -ForegroundColor` | Spectre markup: `[green]Running[/]`, `[red]Stopped[/]` | `Show-WslDistroTable` |
-| Module dependency | None | `PwshSpectreConsole` v2 from PSGallery | Setup process / `Install-Module` |
+| SC-016 Change | Current Implementation | Planned Implementation | Affected Components | Status |
+|---|---|---|---|---|
+| Menu selection | `Read-Host` letter input | `Read-SpectreSelection` arrow-key navigation | `manager.ps1` → `Show-WslMenu` (new) | Done (SC-016b) |
+| Distro table | `Write-Host` with basic colors | `Format-SpectreTable` with borders and colored status | `commands.ps1` → `Show-WslDistroTable` (new) | Done (SC-016c) |
+| Distro picker | `Read-Host` numbered input | `Read-SpectreSelection` for distro lists | `commands.ps1` → `Select-WslDistro` (modified) | Open (SC-016d) |
+| Destructive confirmations | Implicit (no confirmation in TUI) | `Read-SpectreConfirm` for remove, terminate, shutdown | `commands.ps1` → `Confirm-DestructiveAction` (new) | Open (SC-016e) |
+| Status coloring | `Write-Host -ForegroundColor` | Spectre markup: `[green]Running[/]`, `[red]Stopped[/]` | `Show-WslDistroTable` | Done (SC-016c) |
+| Module dependency | None | `PwshSpectreConsole` v2 from PSGallery | Setup process / `Install-Module` | Done (SC-016a) |
 
 ### Key architectural principle
 

--- a/docs/architecture/wsl-manager-c4.md
+++ b/docs/architecture/wsl-manager-c4.md
@@ -112,14 +112,14 @@ C4Component
         Component(docker, "docker.ps1", "PowerShell", "Docker Engine lifecycle: Test-WslDockerInstalled, Install-WslDockerEngine")
         Component(podman, "podman.ps1", "PowerShell", "Rootless Podman lifecycle: Test-WslPodmanInstalled, Install-WslPodman")
         Component(devpod, "devpod.ps1", "PowerShell", "DevPod CLI lifecycle: Test-WslDevPodInstalled, Install-WslDevPod")
-        Component(proxy, "proxy.ps1", "PowerShell", "Proxy configuration: Install-WslProxy — auto-detects PAC/registry, configures .profile, apt, Docker, Podman")
+        Component(proxy, "proxy.ps1", "PowerShell", "Proxy configuration: Install-WslProxy auto-detects PAC/registry/px, configures profile.d + zshenv env, apt, Docker, Podman")
     }
 
     Container_Boundary(scriptContainer, "Bash Install Scripts (lib/wsl/scripts/)") {
         Component(dockerSh, "install-docker.sh", "Bash", "Installs Docker CE, Docker Compose; configures binfmt.d; adds user to docker group")
         Component(podmanSh, "install-podman.sh", "Bash", "Installs Podman rootless; configures subuid/subgid and registries")
         Component(devpodSh, "install-devpod.sh", "Bash", "Downloads DevPod CLI binary; configures container provider (docker/podman)")
-        Component(proxySh, "setup-proxy.sh", "Bash", "Writes proxy env vars to .profile, apt.conf, Docker config, Podman config")
+        Component(proxySh, "setup-proxy.sh", "Bash", "Writes proxy env vars to /etc/profile.d (sourced from zshenv), apt.conf, Docker config, Podman config")
     }
 
     Rel(showMenu, invokeWslCmd, "Selected command")

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -15,7 +15,6 @@
 
 - [SC-001 — Backlog refinement](sc-001.md)
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
-- [SC-045 — Setup-proxy mode prompt: Enter defaults to Auto](sc-045.md)
 
 ### Open
 
@@ -39,6 +38,7 @@
 
 ### Done
 
+- [SC-045 — Setup-proxy mode prompt: Enter defaults to Auto](sc-045.md)
 - [SC-036 — Corporate proxy for WSL without stored credentials](sc-036.md)
 - [SC-036f — Auto proxy setup detects a running Windows px](sc-036f.md)
 - [SC-040 — Add Windows-side px authenticating proxy tool](sc-040.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -15,6 +15,7 @@
 
 - [SC-001 — Backlog refinement](sc-001.md)
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
+- [SC-046 — Make px `[settings]` user-configurable via px-user.ini](sc-046.md)
 
 ### Open
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -15,6 +15,7 @@
 
 - [SC-001 — Backlog refinement](sc-001.md)
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
+- [SC-045 — Setup-proxy mode prompt: Enter defaults to Auto](sc-045.md)
 
 ### Open
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -15,7 +15,6 @@
 
 - [SC-001 — Backlog refinement](sc-001.md)
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
-- [SC-046 — Make px `[settings]` user-configurable via px-user.ini](sc-046.md)
 
 ### Open
 
@@ -39,6 +38,7 @@
 
 ### Done
 
+- [SC-046 — Make px `[settings]` user-configurable via px-user.ini](sc-046.md)
 - [SC-045 — Setup-proxy mode prompt: Enter defaults to Auto](sc-045.md)
 - [SC-036 — Corporate proxy for WSL without stored credentials](sc-036.md)
 - [SC-036f — Auto proxy setup detects a running Windows px](sc-036f.md)

--- a/docs/backlog/sc-045.md
+++ b/docs/backlog/sc-045.md
@@ -1,8 +1,8 @@
 [← Back to Backlog](README.md)
 
-# [SC-045] Setup-proxy mode prompt: Enter defaults to Auto
+# [SC-045] ✅ DONE - Setup-proxy mode prompt: Enter defaults to Auto
 
-**Status**: In Progress
+**Status**: Done (2026-07-20)
 **Priority**: Low
 **Component**: `lib/wsl/proxy.ps1` (`Install-WslProxy`), `lib/wsl/proxy.Tests.ps1`, `docs/wsl-manager.md`
 **Related**: [SC-036a](sc-036a.md) (introduced the `[A]uto/[M]anual/[R]emove` prompt), [SC-036f](sc-036f.md), [SC-040](sc-040.md) (px-proxy)
@@ -28,8 +28,8 @@ Every other prompt in the same function already uses `Get-UserChoice` from `lib/
 - [x] All existing tests continue to pass (proxy unit tests 54/54; full unit suite unchanged at 1099 passed, with the same 17 pre-existing environmental `setup-user` failures present on clean `develop`)
 
 **UAT Procedure**:
-1. [ ] Run `wsl-manager setup-proxy <distro>`; at the mode prompt press **Enter**. Expect: the Auto detection path runs (no "Invalid choice" error).
-2. [ ] Confirm the prompt renders `Proxy setup [A]uto / [m]anual / [r]emove (Enter = Auto)`.
-3. [ ] Typing `M` still goes to the manual `host:port` prompt; `R` still tears down.
+1. [x] Run `wsl-manager setup-proxy <distro>`; at the mode prompt press **Enter**. Expect: the Auto detection path runs (no "Invalid choice" error). (2026-07-20)
+2. [x] Confirm the prompt renders `Proxy setup [A]uto / [m]anual / [r]emove (Enter = Auto)`. (2026-07-20)
+3. [x] Typing `M` still goes to the manual `host:port` prompt; `R` still tears down. (2026-07-20)
 
 [← Back to Backlog](README.md)

--- a/docs/backlog/sc-045.md
+++ b/docs/backlog/sc-045.md
@@ -1,0 +1,35 @@
+[← Back to Backlog](README.md)
+
+# [SC-045] Setup-proxy mode prompt: Enter defaults to Auto
+
+**Status**: In Progress
+**Priority**: Low
+**Component**: `lib/wsl/proxy.ps1` (`Install-WslProxy`), `lib/wsl/proxy.Tests.ps1`, `docs/wsl-manager.md`
+**Related**: [SC-036a](sc-036a.md) (introduced the `[A]uto/[M]anual/[R]emove` prompt), [SC-036f](sc-036f.md), [SC-040](sc-040.md) (px-proxy)
+
+**Summary**:
+As a developer running `wsl-manager setup-proxy`, I want the first prompt (`Auto / Manual / Remove`) to accept Enter as Auto, so that the common case (auto-detect) needs no keystroke beyond Enter, consistent with every other prompt in the flow.
+
+**Description**:
+`Install-WslProxy`'s top-level mode prompt is the only prompt in the function still using a raw `Read-Host` with a regex `switch`. Its `default` branch throws on unrecognized input, and empty input (Enter) falls through to that `default` and errors: pressing Enter is rejected rather than defaulting to Auto. (This was the explicit behavior in SC-036a UAT step 6; SC-045 deliberately changes it.)
+
+Every other prompt in the same function already uses `Get-UserChoice` from `lib/utils/utils.ps1`, whose documented example is literally this prompt: `Get-UserChoice -message "Proxy setup" -options @('Auto','Manual','Remove') -defaultOption 'Auto'`. The fix migrates the mode prompt to that helper. Enter then returns the default (Auto) natively, and invalid input is re-prompted (up to `maxAttempts`) instead of throwing immediately: the same behavior as the auth-method and proxy-selection prompts.
+
+**Scope Decisions**:
+- **Reuse `Get-UserChoice`, not a bespoke empty-input patch**: the helper exists for exactly this prompt (its docstring example) and every sibling prompt already uses it. Migrating removes the last raw `Read-Host` mode prompt and its `switch -Regex`/`default`-throw, so Enter=default and re-prompt-on-invalid come for free and behave identically to the other prompts (DRY).
+- **Invalid-input handling moves to `Get-UserChoice`**: the immediate `throw "Invalid choice..."` is replaced by the helper's re-prompt-then-throw. Coverage for that behavior already lives in `utils.Tests.ps1`, so the proxy-level "Invalid mode choice" test is removed rather than rewritten.
+
+**Acceptance Criteria**:
+- [x] The mode prompt uses `Get-UserChoice` with `-options @('Auto','Manual','Remove')` and `-defaultOption 'Auto'`, so Enter selects Auto
+- [x] Typing `A`/`M`/`R` (or the full labels) still selects Auto/Manual/Remove
+- [x] The raw `Read-Host` mode prompt and its `switch -Regex` `default`-throw are removed
+- [x] `lib/wsl/proxy.Tests.ps1` steers the mode via `Get-UserChoice` mocks and asserts the prompt is invoked with `-defaultOption 'Auto'`; the obsolete proxy-level "Invalid mode choice" test is removed (behavior stays covered by `utils.Tests.ps1`)
+- [x] `docs/wsl-manager.md` notes that Enter defaults to Auto
+- [x] All existing tests continue to pass (proxy unit tests 54/54; full unit suite unchanged at 1099 passed, with the same 17 pre-existing environmental `setup-user` failures present on clean `develop`)
+
+**UAT Procedure**:
+1. [ ] Run `wsl-manager setup-proxy <distro>`; at the mode prompt press **Enter**. Expect: the Auto detection path runs (no "Invalid choice" error).
+2. [ ] Confirm the prompt renders `Proxy setup [A]uto / [m]anual / [r]emove (Enter = Auto)`.
+3. [ ] Typing `M` still goes to the manual `host:port` prompt; `R` still tears down.
+
+[← Back to Backlog](README.md)

--- a/docs/backlog/sc-046.md
+++ b/docs/backlog/sc-046.md
@@ -1,0 +1,43 @@
+[← Back to Backlog](README.md)
+
+# [SC-046] Make px `[settings]` user-configurable via px-user.ini
+
+**Status**: In Progress (2026-07-21)
+**Priority**: Medium
+**Component**: `tools/proxy/px-proxy.ps1` (`Write-PxConfig`, new `Get-PxUserConfigPath` / `Get-PxUserSettings` / template seeding), `tools/proxy/px-proxy.Tests.ps1`, `docs/runbooks/px-proxy.md`
+**Related**: [SC-040](sc-040.md) (px tool and config), [SC-044](sc-044.md) (added the `workers`/`threads` defaults)
+
+**Summary**:
+As a developer running px through this tool, I want to tune px's `[settings]` (logging and pool/timeout knobs) in a user-owned config file so that my values survive `px-proxy start` and I never have to edit PowerShell source.
+
+**Description**:
+`Write-PxConfig` hardcodes the whole `[settings]` block (`log`, `workers`, `threads`, `idle`, `socktimeout`) and **rewrites `px.ini` wholesale on every `start`**. The only way to change a value is to edit the script, which (a) is lost on the next pull, (b) breaks the unit test that asserts the literal block, and (c) mixes user tuning into version-controlled code. Changing `log` for a one-off debugging session is the concrete pain point.
+
+The fix introduces a user-owned override file that is merged into the generated config, keeping the "px.ini is regenerated every start" contract intact while letting user values persist.
+
+**Scope Decisions**:
+- **Separate merged file, not an editable `px.ini`**: a new user-owned `px-user.ini` holds only a `[settings]` block. `Write-PxConfig` overlays those keys onto the built-in defaults (user wins) when generating `px.ini`. `px.ini` stays fully generated and ephemeral (delete = reset to defaults); `px-user.ini` is never overwritten. This matches the mental model "a config file that auto-detection does not clobber" and keeps generated vs user-owned state cleanly separated.
+- **Only `[settings]` is user-overridable**: `[proxy]` (`server`, `listen`, `port`, `auth`) stays tool-managed. `server` is auto-resolved; `listen`/`port` are the `127.0.0.1:3128` contract that WSL (mirrored networking) and native tools depend on. Keys outside `[settings]` in `px-user.ini` are ignored, so a user cannot break that contract.
+- **Default `log = 0` (quiet)**: the shipped default becomes `0` (no debug log) rather than `3`. Logging is opt-in: set `log = 3` in `px-user.ini` when debugging. `workers = 8`, `threads = 32`, `idle = 60`, `socktimeout = 300.0` are unchanged. The existing `Write-PxConfig` unit assertion, the `Write-PxConfig` doc comment, and the runbook (which all currently say `log = 3`) are updated accordingly.
+- **Commented template, seeded not clobbered**: `install` (and `start`, defensively) writes a `px-user.ini` template with all five keys **commented out** and set to their defaults, only when the file is absent. A commented/untouched template therefore behaves exactly like no file. An existing `px-user.ini` is never overwritten.
+- **`remove` preserves `px-user.ini`**: `remove` still deletes `px.ini`, `debug-*.log`, and the install marker, but leaves the user's tuning file so a later reinstall keeps their settings.
+
+**Acceptance Criteria**:
+- [ ] `Get-PxUserConfigPath` returns `<px data dir>\px-user.ini`
+- [ ] `Get-PxUserSettings` parses the `[settings]` section of `px-user.ini` into a hashtable, skipping blank lines and `#`/`;` comments and splitting on the first `=`; returns empty when the file is absent; ignores any keys outside `[settings]`
+- [ ] `Write-PxConfig` emits `[settings]` as built-in defaults overlaid with `Get-PxUserSettings` (user values win), and leaves `[proxy]` (`server`/`listen`/`port`/`auth`) tool-managed even when `px-user.ini` sets those keys
+- [ ] Built-in defaults are `log = 0`, `workers = 8`, `threads = 32`, `idle = 60`, `socktimeout = 300.0`
+- [ ] A commented `px-user.ini` template (all five keys with default values) is seeded when absent on `install` and `start`; an existing `px-user.ini` is never overwritten
+- [ ] `remove` deletes `px.ini`, `debug-*.log`, and the install marker but preserves `px-user.ini`
+- [ ] `px-proxy.Tests.ps1` covers: `Get-PxUserConfigPath`; `Get-PxUserSettings` (missing file, comments/blanks, `[settings]`-only); merge precedence; managed-key immunity; template seed + no-overwrite; and the existing `Write-PxConfig` assertion updated to `log = 0`
+- [ ] `docs/runbooks/px-proxy.md` documents `px-user.ini` (location, overridable keys, that it survives regeneration) and the `log` note reflects default `0` with opt-in `3`
+- [ ] Changed-area unit tests green; no new failures introduced (the 17 environmental `setup-user` failures are unchanged)
+
+**UAT Procedure**:
+1. [ ] Run `px-proxy install`; confirm `px-user.ini` exists as a commented template and `px.ini` `[settings]` shows `log = 0`.
+2. [ ] In `px-user.ini` set `log = 3` and `workers = 12`; run `px-proxy start`; confirm `px.ini` shows `log = 3`, `workers = 12`, and the remaining defaults (`threads = 32`, `idle = 60`, `socktimeout = 300.0`).
+3. [ ] Re-run `px-proxy start`; confirm `px-user.ini` is unchanged and the overrides still apply in `px.ini`.
+4. [ ] Add `listen = 0.0.0.0` and `port = 9999` to `px-user.ini`, run `px-proxy start`; confirm `px.ini` still shows `listen = 127.0.0.1` and `port = 3128`.
+5. [ ] Run `px-proxy remove`; confirm `px.ini` and `debug-*.log` are gone and `px-user.ini` remains.
+
+[← Back to Backlog](README.md)

--- a/docs/backlog/sc-046.md
+++ b/docs/backlog/sc-046.md
@@ -1,8 +1,8 @@
 [← Back to Backlog](README.md)
 
-# [SC-046] Make px `[settings]` user-configurable via px-user.ini
+# [SC-046] ✅ DONE - Make px `[settings]` user-configurable via px-user.ini
 
-**Status**: In Progress (2026-07-21)
+**Status**: Done (2026-07-21)
 **Priority**: Medium
 **Component**: `tools/proxy/px-proxy.ps1` (`Write-PxConfig`, new `Get-PxUserConfigPath` / `Get-PxUserSettings` / template seeding), `tools/proxy/px-proxy.Tests.ps1`, `docs/runbooks/px-proxy.md`
 **Related**: [SC-040](sc-040.md) (px tool and config), [SC-044](sc-044.md) (added the `workers`/`threads` defaults)
@@ -34,10 +34,10 @@ The fix introduces a user-owned override file that is merged into the generated 
 - [x] Changed-area unit tests green (px-proxy 73/73); no new failures introduced (full unit suite: same 17 environmental `setup-user` failures as clean `develop`, unchanged)
 
 **UAT Procedure**:
-1. [ ] Run `px-proxy install`; confirm `px-user.ini` exists as a commented template and `px.ini` `[settings]` shows `log = 0`.
-2. [ ] In `px-user.ini` set `log = 3` and `workers = 12`; run `px-proxy start`; confirm `px.ini` shows `log = 3`, `workers = 12`, and the remaining defaults (`threads = 32`, `idle = 60`, `socktimeout = 300.0`).
-3. [ ] Re-run `px-proxy start`; confirm `px-user.ini` is unchanged and the overrides still apply in `px.ini`.
-4. [ ] Add `listen = 0.0.0.0` and `port = 9999` to `px-user.ini`, run `px-proxy start`; confirm `px.ini` still shows `listen = 127.0.0.1` and `port = 3128`.
-5. [ ] Run `px-proxy remove`; confirm `px.ini` and `debug-*.log` are gone and `px-user.ini` remains.
+1. [x] Run `px-proxy install`; confirm `px-user.ini` exists as a commented template and `px.ini` `[settings]` shows `log = 0`. (2026-07-21)
+2. [x] In `px-user.ini` set `log = 3` and `workers = 12`; run `px-proxy start`; confirm `px.ini` shows `log = 3`, `workers = 12`, and the remaining defaults (`threads = 32`, `idle = 60`, `socktimeout = 300.0`). (2026-07-21)
+3. [x] Re-run `px-proxy start`; confirm `px-user.ini` is unchanged and the overrides still apply in `px.ini`. (2026-07-21)
+4. [x] Add `listen = 0.0.0.0` and `port = 9999` to `px-user.ini`, run `px-proxy start`; confirm `px.ini` still shows `listen = 127.0.0.1` and `port = 3128`. (2026-07-21)
+5. [x] Run `px-proxy remove`; confirm `px.ini` and `debug-*.log` are gone and `px-user.ini` remains. (2026-07-21)
 
 [← Back to Backlog](README.md)

--- a/docs/backlog/sc-046.md
+++ b/docs/backlog/sc-046.md
@@ -23,15 +23,15 @@ The fix introduces a user-owned override file that is merged into the generated 
 - **`remove` preserves `px-user.ini`**: `remove` still deletes `px.ini`, `debug-*.log`, and the install marker, but leaves the user's tuning file so a later reinstall keeps their settings.
 
 **Acceptance Criteria**:
-- [ ] `Get-PxUserConfigPath` returns `<px data dir>\px-user.ini`
-- [ ] `Get-PxUserSettings` parses the `[settings]` section of `px-user.ini` into a hashtable, skipping blank lines and `#`/`;` comments and splitting on the first `=`; returns empty when the file is absent; ignores any keys outside `[settings]`
-- [ ] `Write-PxConfig` emits `[settings]` as built-in defaults overlaid with `Get-PxUserSettings` (user values win), and leaves `[proxy]` (`server`/`listen`/`port`/`auth`) tool-managed even when `px-user.ini` sets those keys
-- [ ] Built-in defaults are `log = 0`, `workers = 8`, `threads = 32`, `idle = 60`, `socktimeout = 300.0`
-- [ ] A commented `px-user.ini` template (all five keys with default values) is seeded when absent on `install` and `start`; an existing `px-user.ini` is never overwritten
-- [ ] `remove` deletes `px.ini`, `debug-*.log`, and the install marker but preserves `px-user.ini`
-- [ ] `px-proxy.Tests.ps1` covers: `Get-PxUserConfigPath`; `Get-PxUserSettings` (missing file, comments/blanks, `[settings]`-only); merge precedence; managed-key immunity; template seed + no-overwrite; and the existing `Write-PxConfig` assertion updated to `log = 0`
-- [ ] `docs/runbooks/px-proxy.md` documents `px-user.ini` (location, overridable keys, that it survives regeneration) and the `log` note reflects default `0` with opt-in `3`
-- [ ] Changed-area unit tests green; no new failures introduced (the 17 environmental `setup-user` failures are unchanged)
+- [x] `Get-PxUserConfigPath` returns `<px data dir>\px-user.ini`
+- [x] `Get-PxUserSetting` parses the `[settings]` section of `px-user.ini` into a hashtable, skipping blank lines and `#`/`;` comments, stripping inline comments, and splitting on the first `=`; returns empty when the file is absent; ignores any keys outside `[settings]`
+- [x] `Write-PxConfig` emits `[settings]` as built-in defaults (`Get-PxDefaultSetting`) overlaid with `Get-PxUserSetting` (user values win), and leaves `[proxy]` (`server`/`listen`/`port`/`auth`) tool-managed even when `px-user.ini` sets those keys
+- [x] Built-in defaults are `log = 0`, `workers = 8`, `threads = 32`, `idle = 60`, `socktimeout = 300.0`
+- [x] A commented `px-user.ini` template (all five keys with default values) is seeded when absent on `install` and `start`; an existing `px-user.ini` is never overwritten
+- [x] `remove` deletes `px.ini`, `debug-*.log`, and the install marker but preserves `px-user.ini`
+- [x] `px-proxy.Tests.ps1` covers: `Get-PxUserConfigPath`; `Get-PxUserSetting` (missing file, comments/blanks, inline comments, `[settings]`-only); merge precedence; managed-key immunity; template seed + no-overwrite; and the existing `Write-PxConfig` assertion updated to `log = 0`
+- [x] `docs/runbooks/px-proxy.md` documents `px-user.ini` (location, overridable keys, that it survives regeneration) and the `log` note reflects default `0` with opt-in `3`
+- [x] Changed-area unit tests green (px-proxy 73/73); no new failures introduced (full unit suite: same 17 environmental `setup-user` failures as clean `develop`, unchanged)
 
 **UAT Procedure**:
 1. [ ] Run `px-proxy install`; confirm `px-user.ini` exists as a commented template and `px.ini` `[settings]` shows `log = 0`.

--- a/docs/runbooks/px-proxy.md
+++ b/docs/runbooks/px-proxy.md
@@ -36,11 +36,11 @@ Run from Keypirinha (type `px-proxy`) or from a terminal:
 
 | Action    | What it does |
 |-----------|--------------|
-| `install` | Installs px via Scoop (only if not already present) and creates the px data directory. Does **not** resolve the proxy or write config. |
-| `start`   | Resolves the upstream proxy fresh, (re)writes the px config, and always (re)starts px. Exactly one `pxw.exe` instance results. |
+| `install` | Installs px via Scoop (only if not already present), creates the px data directory, and seeds a `px-user.ini` settings template. Does **not** resolve the proxy or write config. |
+| `start`   | Resolves the upstream proxy fresh, (re)writes the px config (merging your `px-user.ini` overrides), and always (re)starts px. Exactly one `pxw.exe` instance results. |
 | `stop`    | Stops any running px cleanly. |
 | `test`    | Sends an HTTPS request through `127.0.0.1:3128` and reports a clear diagnostic. |
-| `remove`  | Stops px, uninstalls it (only if this tool installed it), and deletes the config and log files. |
+| `remove`  | Stops px, uninstalls it (only if this tool installed it), and deletes `px.ini` and the log files. Your `px-user.ini` is preserved. |
 
 `start` is the default action when none is given.
 
@@ -103,8 +103,35 @@ To check px directly, bypassing the environment, add `-x http://127.0.0.1:3128`.
 ## Files and logs
 
 - **Data directory:** `%USERPROFILE%\.config\px`
-- **Config:** `%USERPROFILE%\.config\px\px.ini` (regenerated on every `start`)
-- **Log:** `%USERPROFILE%\.config\px\debug-*.log` (`[settings] log = 3` writes a unique log in px's working directory, which `start` sets to the data dir; `remove` deletes these)
+- **Generated config:** `%USERPROFILE%\.config\px\px.ini` (regenerated on every `start`; do not hand-edit, your changes are overwritten)
+- **User settings:** `%USERPROFILE%\.config\px\px-user.ini` (your overrides; never overwritten by the tool and preserved on `remove`; see [Customizing settings](#customizing-settings))
+- **Log:** `%USERPROFILE%\.config\px\debug-*.log` (off by default; set `log = 3` in `px-user.ini` to write a unique log in px's working directory, which `start` sets to the data dir; `remove` deletes these)
+
+---
+
+## Customizing settings
+
+`px.ini` is regenerated on every `start`, so it is not the place for your own changes. Put overrides in `%USERPROFILE%\.config\px\px-user.ini` instead: the tool merges them over its defaults and never overwrites the file. `install` (and the first `start`) seed a commented template listing every key.
+
+Only the `[settings]` block is read; the `[proxy]` block (`server`, `listen`, `port`) stays tool-managed, so nothing here can move the `127.0.0.1:3128` endpoint or the resolved upstream. Overridable keys and their defaults:
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `log` | `0` | Log level. `0` = off; `3` = verbose `debug-*.log` for troubleshooting. |
+| `workers` | `8` | Connection worker processes. |
+| `threads` | `32` | Threads per worker. |
+| `idle` | `60` | Seconds an idle upstream connection is kept. |
+| `socktimeout` | `300.0` | Socket timeout (seconds) for long-running requests. |
+
+Example `px-user.ini` that turns logging on and enlarges the pool:
+
+```ini
+[settings]
+log = 3
+workers = 12
+```
+
+Run `start` to apply. Delete `px-user.ini` (or a single line) to return to defaults.
 
 ---
 
@@ -136,7 +163,7 @@ Confirm px is running and reachable:
 .\tools\proxy\px-proxy.ps1 test
 ```
 
-Then read the px log at `%USERPROFILE%\.config\px\debug-*.log`. Re-run `start` to regenerate the config and restart px.
+Logging is off by default; set `log = 3` in `px-user.ini` (see [Customizing settings](#customizing-settings)) and re-run `start`, then read the px log at `%USERPROFILE%\.config\px\debug-*.log`. Re-running `start` also regenerates the config and restarts px.
 
 ---
 

--- a/docs/wsl-manager.md
+++ b/docs/wsl-manager.md
@@ -702,7 +702,7 @@ Configure corporate proxy settings with automatic detection. Auto-detects proxy 
 - **CLI**: `.\tools\wsl-manager\wsl-manager.ps1 setup-proxy <distro>`
 
 This command:
-- Prompts upfront for setup mode: `[A]uto` (PAC detection), `[M]anual` (enter host:port), or `[R]emove` (tear down)
+- Prompts upfront for setup mode: `[A]uto` (PAC detection), `[M]anual` (enter host:port), or `[R]emove` (tear down); pressing Enter selects Auto
 - Auto mode reads `AutoConfigURL` from Windows Internet Settings and asks for confirmation before proceeding
 - Auto → DIRECT collapses to Remove (no proxy needed on this network)
 - Auto mode also probes for a running local **px** proxy (see [px Proxy runbook](runbooks/px-proxy.md)). When px is up, you choose between the px endpoint (`http://127.0.0.1:3128`, reachable from WSL via mirrored networking — px authenticates to the corporate proxy via SSPI on the Windows host, so no credentials are stored) and the PAC-detected corporate proxy

--- a/docs/wsl-manager.md
+++ b/docs/wsl-manager.md
@@ -851,28 +851,34 @@ This command:
 
 ```
 tools/wsl-manager/
-├── wsl-manager.ps1            # Entry point (params + bootstrapping)
-├── wsl-manager.bat            # Batch wrapper for Keypirinha
-├── wsl.Integration.Tests.ps1
-├── manager.docker.Integration.Tests.ps1
-└── manager.podman.Integration.Tests.ps1
+├── wsl-manager.ps1            # Entry point (params + bootstrapping); sources lib/wsl/manager.ps1
+└── wsl-manager.bat            # Batch wrapper for Keypirinha
 
 lib/wsl/
-├── wsl.ps1                    # Main library (dot-sources all modules)
-├── commands.ps1               # CLI dispatch, TUI menu & workflows
-├── core.ps1                   # List, get distro info, type detection
-├── docker.ps1                 # Docker installation & verification
-├── exec.ps1                   # Script execution in WSL
-├── install.ps1                # Clone, remove operations
-├── ops.ps1                    # Update, state, terminate operations
-├── podman.ps1                 # Podman installation & verification
-├── proxy.ps1                  # Proxy configuration
+├── wsl.ps1                    # Library facade (dot-sources all feature modules below)
+├── manager.ps1                # Orchestration: CLI dispatch + TUI menu
+├── commands.ps1               # Action functions for each command
+├── spectre.ps1                # PwshSpectreConsole loader for the TUI
+├── core.ps1                   # WSL/distro checks: list, state, type detection, terminate
+├── install.ps1                # Discover available distros, install new instances
+├── ops.ps1                    # Remove, copy, update, shutdown, .wslconfig defaults
+├── wsl-conf.ps1               # Per-distro /etc/wsl.conf read/merge/write
 ├── user.ps1                   # User account creation & configuration
+├── exec.ps1                   # Script execution in WSL
+├── docker.ps1                 # Docker installation & verification
+├── podman.ps1                 # Podman installation & verification
+├── devpod.ps1                 # DevPod CLI installation & checks
+├── ssh.ps1                    # SSH key/config sync between Windows and WSL
+├── proxy.ps1                  # Proxy configuration
 └── scripts/
     ├── install-docker.sh          # Docker Engine installation script
     ├── install-podman.sh          # Rootless Podman installation script
-    └── setup-proxy.sh             # Proxy configuration script (env, apt, Docker, Podman)
+    ├── install-devpod.sh          # DevPod CLI installation script
+    ├── setup-proxy.sh             # Proxy configuration (env, apt, Docker, Podman)
+    └── sync-ssh-config.sh         # SSH config sync between Windows host and WSL
 ```
+
+Each module has a co-located `*.Tests.ps1` unit test (omitted above). Integration tests (`wsl.Integration.Tests.ps1`, `manager.docker.Integration.Tests.ps1`, `manager.podman.Integration.Tests.ps1`) live alongside the modules in `lib/wsl/`.
 
 ### Library Usage
 

--- a/docs/wsl-manager.md
+++ b/docs/wsl-manager.md
@@ -707,7 +707,8 @@ This command:
 - Auto → DIRECT collapses to Remove (no proxy needed on this network)
 - Auto mode also probes for a running local **px** proxy (see [px Proxy runbook](runbooks/px-proxy.md)). When px is up, you choose between the px endpoint (`http://127.0.0.1:3128`, reachable from WSL via mirrored networking — px authenticates to the corporate proxy via SSPI on the Windows host, so no credentials are stored) and the PAC-detected corporate proxy
 - After a corporate proxy URL is resolved, prompts for auth method: `[A]nonymous` (no credentials) or `[B]asic` (username/password embedded in the URL, prefilled with your Windows username)
-- Configures `~/.profile` managed block with `http_proxy`, `https_proxy`, `no_proxy` exports
+- Writes proxy exports (`http_proxy`, `https_proxy`, `no_proxy`, and their uppercase variants) to a managed file `/etc/profile.d/wsl-manager-proxy.sh`, and sources it from `/etc/zsh/zshenv` so both bash and zsh pick them up on a normal WSL launch; legacy `~/.profile`, `~/.bashrc`, and `/etc/environment` blocks are migrated away
+- Points tools that ship their own CA bundle (uv, Node, pip/requests, Go) at the system trust store via `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, and `PIP_CERT` so corporate TLS inspection works
 - Configures `/etc/apt/apt.conf.d/99proxy` for APT package manager
 - Configures `~/.docker/config.json` proxy settings
 - Configures `~/.config/containers/containers.conf` for Podman

--- a/lib/wsl/proxy.Tests.ps1
+++ b/lib/wsl/proxy.Tests.ps1
@@ -31,7 +31,7 @@ Describe "Install-WslProxy" {
         Mock Test-PxProxyAvailable { $false }
         # Default prompt answers — filtered mocks take precedence, so tests only
         # override the prompts they care about.
-        Mock Read-Host -ParameterFilter { $Prompt -like "*Proxy setup*" } -MockWith { "A" }
+        Mock Get-UserChoice -ParameterFilter { $message -like "*Proxy setup*" } -MockWith { "Auto" }
         Mock Get-UserConfirmation -MockWith { $true }
         # Auth method defaults to Basic; credentials are empty unless a test asks.
         Mock Get-UserChoice -ParameterFilter { $message -like "*Auth method*" } -MockWith { 'Basic' }
@@ -49,7 +49,7 @@ Describe "Install-WslProxy" {
         }
 
         It "Should terminate the distribution on Remove teardown success" {
-            Mock Read-Host -ParameterFilter { $Prompt -like "*Proxy setup*" } -MockWith { "R" }
+            Mock Get-UserChoice -ParameterFilter { $message -like "*Proxy setup*" } -MockWith { "Remove" }
 
             Install-WslProxy -DistroName "Debian" -Confirm:$false
 
@@ -286,9 +286,26 @@ Describe "Install-WslProxy" {
         }
     }
 
+    Context "Mode prompt — Enter defaults to Auto" {
+        It "Should present Auto/Manual/Remove via Get-UserChoice with Auto as the Enter default" {
+            Mock Get-InternetSettingsFromRegistry { [PSCustomObject]@{ AutoConfigURL = "http://pac.corp.com/proxy.pac" } }
+            Mock Get-ProxyFromPac { @{ ProxyUrl = "http://proxy.corp.com:8080"; IsDirect = $false } }
+
+            Install-WslProxy -DistroName "Debian" -Confirm:$false
+
+            Should -Invoke Get-UserChoice -Times 1 -ParameterFilter {
+                $message -like "*Proxy setup*" -and
+                $defaultOption -eq 'Auto' -and
+                ($options -contains 'Auto') -and
+                ($options -contains 'Manual') -and
+                ($options -contains 'Remove')
+            }
+        }
+    }
+
     Context "Manual — user enters host:port" {
         It "Should use manually entered proxy URL and not probe PAC or px" {
-            Mock Read-Host -ParameterFilter { $Prompt -like "*Proxy setup*" } -MockWith { "M" }
+            Mock Get-UserChoice -ParameterFilter { $message -like "*Proxy setup*" } -MockWith { "Manual" }
             Mock Read-Host -ParameterFilter { $Prompt -like "*host:port*" } -MockWith { "myproxy.com:8080" }
             Mock Get-ProxyFromPac { throw "PAC must not be probed on Manual path" }
 
@@ -314,7 +331,7 @@ Describe "Install-WslProxy" {
         }
 
         It "Should throw when host:port is empty" {
-            Mock Read-Host -ParameterFilter { $Prompt -like "*Proxy setup*" } -MockWith { "M" }
+            Mock Get-UserChoice -ParameterFilter { $message -like "*Proxy setup*" } -MockWith { "Manual" }
             Mock Read-Host -ParameterFilter { $Prompt -like "*host:port*" } -MockWith { "" }
 
             { Install-WslProxy -DistroName "Debian" -Confirm:$false } | Should -Throw "*host:port*"
@@ -324,7 +341,7 @@ Describe "Install-WslProxy" {
 
     Context "Remove — dispatches teardown" {
         It "Should call setup-proxy.sh with --remove flag" {
-            Mock Read-Host -ParameterFilter { $Prompt -like "*Proxy setup*" } -MockWith { "R" }
+            Mock Get-UserChoice -ParameterFilter { $message -like "*Proxy setup*" } -MockWith { "Remove" }
 
             Install-WslProxy -DistroName "Debian" -Confirm:$false
 
@@ -335,7 +352,7 @@ Describe "Install-WslProxy" {
         }
 
         It "Should skip auth method and credentials prompts" {
-            Mock Read-Host -ParameterFilter { $Prompt -like "*Proxy setup*" } -MockWith { "R" }
+            Mock Get-UserChoice -ParameterFilter { $message -like "*Proxy setup*" } -MockWith { "Remove" }
 
             Install-WslProxy -DistroName "Debian" -Confirm:$false
 
@@ -344,22 +361,13 @@ Describe "Install-WslProxy" {
         }
 
         It "Should not run PAC or px detection" {
-            Mock Read-Host -ParameterFilter { $Prompt -like "*Proxy setup*" } -MockWith { "R" }
+            Mock Get-UserChoice -ParameterFilter { $message -like "*Proxy setup*" } -MockWith { "Remove" }
             Mock Get-ProxyFromPac { throw "PAC must not be probed on Remove path" }
 
             Install-WslProxy -DistroName "Debian" -Confirm:$false
 
             Should -Invoke Get-ProxyFromPac -Times 0
             Should -Invoke Test-PxProxyAvailable -Times 0
-        }
-    }
-
-    Context "Invalid mode choice" {
-        It "Should throw on unrecognized input" {
-            Mock Read-Host -ParameterFilter { $Prompt -like "*Proxy setup*" } -MockWith { "X" }
-
-            { Install-WslProxy -DistroName "Debian" -Confirm:$false } | Should -Throw "*Invalid choice*"
-            Should -Invoke Invoke-WslDistroScript -Times 0
         }
     }
 

--- a/lib/wsl/proxy.ps1
+++ b/lib/wsl/proxy.ps1
@@ -78,9 +78,9 @@ function Install-WslProxy {
     $isDirect = $false
     $authMode = $null
 
-    $modeChoice = Read-Host "Proxy setup: [A]uto / [M]anual / [R]emove"
-    switch -Regex ($modeChoice) {
-        '^\s*[Aa]' {
+    $modeChoice = Get-UserChoice -message "Proxy setup" -options @('Auto', 'Manual', 'Remove') -defaultOption 'Auto'
+    switch ($modeChoice) {
+        'Auto' {
             # Auto: detect BOTH sources up front, report the findings in one place,
             # then present a single selection. Detection output is never interleaved
             # with the prompt, and the resolved values are shown before the user
@@ -166,7 +166,7 @@ function Install-WslProxy {
             }
             break
         }
-        '^\s*[Mm]' {
+        'Manual' {
             $manualEntry = Read-Host "Enter proxy host:port (e.g. proxy.corp.com:8080)"
             if ([string]::IsNullOrWhiteSpace($manualEntry)) {
                 throw "No proxy host:port provided."
@@ -174,12 +174,9 @@ function Install-WslProxy {
             $ProxyUrl = "http://$manualEntry"
             break
         }
-        '^\s*[Rr]' {
+        'Remove' {
             $isDirect = $true
             break
-        }
-        default {
-            throw "Invalid choice '$modeChoice'. Expected [A]uto, [M]anual, or [R]emove."
         }
     }
 

--- a/tools/proxy/px-proxy.Tests.ps1
+++ b/tools/proxy/px-proxy.Tests.ps1
@@ -204,20 +204,119 @@ Describe "Resolve-PxUpstreamProxy" {
     }
 }
 
+Describe "Get-PxUserConfigPath" {
+    It "returns px-user.ini inside the data directory" {
+        Mock Get-PxDataDir { 'C:\fake\px' }
+        Get-PxUserConfigPath | Should -Be 'C:\fake\px\px-user.ini'
+    }
+}
+
+Describe "Get-PxUserSetting" {
+    BeforeEach {
+        Mock Get-PxDataDir { $script:TestDataDir }
+        New-Item -ItemType Directory -Path $script:TestDataDir -Force | Out-Null
+        Remove-Item (Join-Path $script:TestDataDir 'px-user.ini') -ErrorAction SilentlyContinue
+    }
+
+    It "returns an empty map when the user file is absent" {
+        (Get-PxUserSetting).Count | Should -Be 0
+    }
+
+    It "parses [settings] keys and ignores comments and blank lines" {
+        $userConfig = @'
+# a leading comment
+[settings]
+log = 3
+; semicolon comment
+workers = 12
+
+threads = 40
+'@
+        Set-Content -Path (Get-PxUserConfigPath) -Value $userConfig -Encoding ascii
+
+        $settings = Get-PxUserSetting
+        $settings.Count | Should -Be 3
+        $settings['log'] | Should -Be '3'
+        $settings['workers'] | Should -Be '12'
+        $settings['threads'] | Should -Be '40'
+    }
+
+    It "strips inline comments from values" {
+        $userConfig = @'
+[settings]
+log = 0   # inline note
+workers = 12 ; another
+'@
+        Set-Content -Path (Get-PxUserConfigPath) -Value $userConfig -Encoding ascii
+
+        $settings = Get-PxUserSetting
+        $settings['log'] | Should -Be '0'
+        $settings['workers'] | Should -Be '12'
+    }
+
+    It "ignores keys outside the [settings] section" {
+        $userConfig = @'
+[proxy]
+server = evil.corp:1234
+listen = 0.0.0.0
+
+[settings]
+log = 3
+'@
+        Set-Content -Path (Get-PxUserConfigPath) -Value $userConfig -Encoding ascii
+
+        $settings = Get-PxUserSetting
+        $settings.ContainsKey('server') | Should -BeFalse
+        $settings.ContainsKey('listen') | Should -BeFalse
+        $settings['log'] | Should -Be '3'
+    }
+}
+
+Describe "New-PxUserConfigTemplate" {
+    BeforeEach {
+        Mock Get-PxDataDir { $script:TestDataDir }
+        Mock New-Directory { New-Item -ItemType Directory -Path $Path -Force | Out-Null }
+        New-Item -ItemType Directory -Path $script:TestDataDir -Force | Out-Null
+        Remove-Item (Join-Path $script:TestDataDir 'px-user.ini') -ErrorAction SilentlyContinue
+    }
+
+    It "seeds a fully commented template when the file is absent" {
+        New-PxUserConfigTemplate
+        $path = Get-PxUserConfigPath
+        Test-Path $path | Should -BeTrue
+        $content = Get-Content -Raw $path
+        $content | Should -Match '\[settings\]'
+        # Every overridable key ships commented out so an untouched template
+        # behaves exactly like no file (pure defaults).
+        $content | Should -Match '(?m)^#\s*log\b'
+        $content | Should -Match '(?m)^#\s*workers\b'
+        (Get-PxUserSetting).Count | Should -Be 0
+    }
+
+    It "never overwrites an existing user file" {
+        Set-Content -Path (Get-PxUserConfigPath) -Value 'MINE' -Encoding ascii
+        New-PxUserConfigTemplate
+        Get-Content -Raw (Get-PxUserConfigPath) | Should -Match 'MINE'
+    }
+}
+
 Describe "Write-PxConfig" {
     BeforeEach {
         Mock Get-PxDataDir { $script:TestDataDir }
         Mock New-Directory { New-Item -ItemType Directory -Path $Path -Force | Out-Null }
+        New-Item -ItemType Directory -Path $script:TestDataDir -Force | Out-Null
+        Remove-Item (Join-Path $script:TestDataDir 'px-user.ini') -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $script:TestDataDir 'px.ini') -ErrorAction SilentlyContinue
     }
 
-    It "writes a px.ini containing the resolved upstream proxy and logging" {
+    It "writes a px.ini with the resolved upstream proxy and default settings (log off)" {
         $path = Write-PxConfig -UpstreamProxy 'up.corp:8080'
         $path | Should -Be (Join-Path $script:TestDataDir 'px.ini')
         $content = Get-Content -Raw $path
         $content | Should -Match 'server = up\.corp:8080'
         $content | Should -Match 'listen = 127\.0\.0\.1'
         $content | Should -Match 'port = 3128'
-        $content | Should -Match 'log = 3'
+        $content | Should -Match 'log = 0'
         $content | Should -Match 'idle = 60'
         $content | Should -Match 'socktimeout = 300\.0'
         $content | Should -Match 'workers = 8'
@@ -230,6 +329,49 @@ Describe "Write-PxConfig" {
         $content = Get-Content -Raw $path
         $content | Should -Match 'server = second\.corp:8080'
         $content | Should -Not -Match 'first\.corp'
+    }
+
+    It "applies user [settings] overrides over the built-in defaults" {
+        $userConfig = @'
+[settings]
+log = 3
+workers = 12
+'@
+        Set-Content -Path (Get-PxUserConfigPath) -Value $userConfig -Encoding ascii
+
+        $content = Get-Content -Raw (Write-PxConfig -UpstreamProxy 'up.corp:8080')
+        $content | Should -Match 'log = 3'
+        $content | Should -Match 'workers = 12'
+        # Untouched keys keep their defaults.
+        $content | Should -Match 'threads = 32'
+        $content | Should -Match 'idle = 60'
+        $content | Should -Match 'socktimeout = 300\.0'
+    }
+
+    It "keeps managed [proxy] keys even when the user file tries to set them" {
+        $userConfig = @'
+[settings]
+server = evil.corp:1234
+listen = 0.0.0.0
+port = 9999
+log = 3
+'@
+        Set-Content -Path (Get-PxUserConfigPath) -Value $userConfig -Encoding ascii
+
+        $content = Get-Content -Raw (Write-PxConfig -UpstreamProxy 'up.corp:8080')
+        $content | Should -Match 'server = up\.corp:8080'
+        $content | Should -Match 'listen = 127\.0\.0\.1'
+        $content | Should -Match 'port = 3128'
+        $content | Should -Not -Match '0\.0\.0\.0'
+        $content | Should -Not -Match '9999'
+        $content | Should -Not -Match 'evil'
+        # A legitimate [settings] override still applies.
+        $content | Should -Match 'log = 3'
+    }
+
+    It "seeds the user template when it is absent" {
+        Write-PxConfig -UpstreamProxy 'up.corp:8080' | Out-Null
+        Test-Path (Get-PxUserConfigPath) | Should -BeTrue
     }
 }
 
@@ -251,6 +393,13 @@ Describe "Install-PxProxy" {
         Mock Test-PxInstalled { $true }
         Install-PxProxy
         Should -Invoke Invoke-CommandLine -Times 0
+    }
+
+    It "seeds the px-user.ini template" {
+        Mock Test-PxInstalled { $true }
+        Remove-Item (Get-PxUserConfigPath) -ErrorAction SilentlyContinue
+        Install-PxProxy
+        Test-Path (Get-PxUserConfigPath) | Should -BeTrue
     }
 }
 
@@ -472,6 +621,15 @@ Describe "Remove-PxProxy" {
         Set-Content -Path (Get-PxConfigPath) -Value 'stale'
         Remove-PxProxy
         Test-Path (Get-PxConfigPath) | Should -BeFalse
+    }
+
+    It "preserves the user config file so tuning survives a reinstall" {
+        Set-Content -Path (Get-PxUserConfigPath) -Value 'MINE' -Encoding ascii
+        Set-Content -Path (Get-PxConfigPath) -Value 'stale'
+        Remove-PxProxy
+        Test-Path (Get-PxConfigPath) | Should -BeFalse
+        Test-Path (Get-PxUserConfigPath) | Should -BeTrue
+        Get-Content -Raw (Get-PxUserConfigPath) | Should -Match 'MINE'
     }
 }
 

--- a/tools/proxy/px-proxy.ps1
+++ b/tools/proxy/px-proxy.ps1
@@ -107,13 +107,30 @@ function Get-PxDataDir {
 function Get-PxConfigPath {
     <#
     .SYNOPSIS
-        Returns the full path to the px config file (px.ini).
+        Returns the full path to the generated px config file (px.ini).
     #>
     [CmdletBinding()]
     [OutputType([string])]
     param()
 
     return (Join-Path (Get-PxDataDir) 'px.ini')
+}
+
+function Get-PxUserConfigPath {
+    <#
+    .SYNOPSIS
+        Returns the full path to the user-owned override file (px-user.ini).
+
+    .DESCRIPTION
+        px-user.ini holds a '[settings]' block whose keys are merged over the
+        built-in defaults when px.ini is generated. Unlike px.ini it is never
+        overwritten by the tool, so user tuning survives every 'start' (SC-046).
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    return (Join-Path (Get-PxDataDir) 'px-user.ini')
 }
 
 function Get-PxInstalledMarkerPath {
@@ -306,19 +323,143 @@ function Resolve-PxUpstreamProxy {
 }
 
 # --- px config ------------------------------------------------------------
+
+# Keys the tool owns; a user cannot override these from px-user.ini because the
+# WSL/native-tool contract (127.0.0.1:3128) and the resolved upstream depend on
+# them. Compared case-insensitively.
+$script:PxManagedSettingKeys = @('server', 'listen', 'port', 'auth')
+
+# Built-in [settings] defaults, in emission order. log defaults to 0 (quiet):
+# set log = 3 in px-user.ini to capture a debug log when troubleshooting.
+# idle/socktimeout sit above px's defaults so long AI-agent requests (Claude
+# Code, Copilot CLI) are not dropped; workers/threads sit above px's low
+# defaults (2/5) so parallel connection bursts are not refused (SC-044).
+function Get-PxDefaultSetting {
+    <#
+    .SYNOPSIS
+        Returns the built-in px '[settings]' defaults as an ordered map.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Collections.Specialized.OrderedDictionary])]
+    param()
+
+    return [ordered]@{
+        log         = '0'
+        workers     = '8'
+        threads     = '32'
+        idle        = '60'
+        socktimeout = '300.0'
+    }
+}
+
+function Get-PxUserSetting {
+    <#
+    .SYNOPSIS
+        Parses the '[settings]' block of px-user.ini into a hashtable.
+
+    .DESCRIPTION
+        Reads px-user.ini (if present) and returns the key/value pairs under its
+        '[settings]' section. Blank lines and '#'/';' comments are ignored, and
+        only the '[settings]' section is read: keys in any other section (e.g. a
+        stray '[proxy]') are dropped so they can never affect the generated
+        config. Returns an empty map when the file is absent.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
+
+    $settings = @{}
+
+    $path = Get-PxUserConfigPath
+    if (-not (Test-Path $path)) {
+        return $settings
+    }
+
+    $inSettings = $false
+    foreach ($raw in (Get-Content -Path $path)) {
+        $line = $raw.Trim()
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        if ($line.StartsWith('#') -or $line.StartsWith(';')) { continue }
+
+        if ($line -match '^\[(?<section>.+)\]$') {
+            $inSettings = ($Matches['section'].Trim() -eq 'settings')
+            continue
+        }
+
+        if (-not $inSettings) { continue }
+
+        $idx = $line.IndexOf('=')
+        if ($idx -lt 1) { continue }
+
+        $key = $line.Substring(0, $idx).Trim()
+        $value = $line.Substring($idx + 1).Trim()
+        # Strip an inline comment (whitespace then '#' or ';'). px's configparser
+        # would otherwise treat it as part of the value and fail to parse.
+        $value = ($value -split '\s[#;]', 2)[0].Trim()
+        if (-not [string]::IsNullOrWhiteSpace($key)) {
+            $settings[$key] = $value
+        }
+    }
+
+    return $settings
+}
+
+function New-PxUserConfigTemplate {
+    <#
+    .SYNOPSIS
+        Seeds a commented px-user.ini template when the file is absent.
+
+    .DESCRIPTION
+        Writes a self-documenting template listing every overridable key,
+        commented out and set to its default, so an untouched template behaves
+        exactly like no file. Never overwrites an existing px-user.ini.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
+
+    $path = Get-PxUserConfigPath
+    if (Test-Path $path) {
+        return
+    }
+
+    New-Directory -Path (Get-PxDataDir)
+
+    $content = @"
+# px-proxy user settings (SC-046) -- overrides the generated px.ini.
+# Only the [settings] block below is read; [proxy] (server/listen/port) stays
+# managed by the tool. Uncomment a key to change it; delete this file to reset
+# to defaults. px-proxy never overwrites this file.
+[settings]
+# Log level: 0 = off (default); 3 = verbose debug-<pid>.log for troubleshooting.
+# log = 0
+# Connection worker processes.
+# workers = 8
+# Threads per worker.
+# threads = 32
+# Seconds an idle upstream connection is kept.
+# idle = 60
+# Socket timeout (seconds) for long-running requests.
+# socktimeout = 300.0
+"@
+
+    if ($PSCmdlet.ShouldProcess($path, "Write px-user.ini template")) {
+        Set-Content -Path $path -Value $content -Encoding ascii
+    }
+}
+
 function Write-PxConfig {
     <#
     .SYNOPSIS
-        (Re)writes the px config from the resolved upstream proxy.
+        (Re)writes the px config from the resolved upstream proxy and user overrides.
 
     .DESCRIPTION
-        Overwrites px.ini every call. Enables logging (log = 3: unique
-        debug-<pid>.log in px's working directory, which start sets to the px
-        data directory). Raises idle/socktimeout above px's defaults so long
-        AI agent requests (e.g. Copilot CLI, Claude Code) don't get dropped
-        mid-response, and raises workers/threads above px's low defaults
-        (2/5) so parallel connection bursts from those tools aren't refused
-        when the pool or listen backlog overflows (SC-044).
+        Overwrites px.ini every call. The '[proxy]' block is tool-managed
+        (server resolved fresh; listen/port fixed). The '[settings]' block is
+        the built-in defaults (Get-PxDefaultSettings) with any user overrides
+        from px-user.ini's '[settings]' merged on top (user wins). Managed keys
+        are stripped from the user overrides so nothing in px-user.ini can move
+        the listen endpoint or upstream. Also seeds the px-user.ini template
+        when absent so the overridable keys are discoverable (SC-046).
 
     .PARAMETER UpstreamProxy
         The upstream proxy 'host:port' px authenticates to.
@@ -334,7 +475,23 @@ function Write-PxConfig {
     $dir = Get-PxDataDir
     New-Directory -Path $dir
 
+    # Make the override file discoverable on first use.
+    New-PxUserConfigTemplate
+
     $configPath = Get-PxConfigPath
+
+    # Merge user [settings] over the defaults, then append any extra user keys.
+    # Managed keys are dropped up front so they can never leak into px.ini.
+    $merged = Get-PxDefaultSetting
+    $userSettings = Get-PxUserSetting
+    foreach ($managed in $script:PxManagedSettingKeys) {
+        $userSettings.Remove($managed)
+    }
+    foreach ($key in $userSettings.Keys) {
+        $merged[$key] = $userSettings[$key]
+    }
+
+    $settingsBlock = ($merged.Keys | ForEach-Object { "$_ = $($merged[$_])" }) -join "`n"
 
     $content = @"
 [proxy]
@@ -344,11 +501,7 @@ port = $script:PxPort
 auth =
 
 [settings]
-log = 3
-workers = 8
-threads = 32
-idle = 60
-socktimeout = 300.0
+$settingsBlock
 "@
 
     if ($PSCmdlet.ShouldProcess($configPath, "Write px config")) {
@@ -368,6 +521,7 @@ function Install-PxProxy {
     param()
 
     New-Directory -Path (Get-PxDataDir)
+    New-PxUserConfigTemplate
 
     if (Test-PxInstalled) {
         Write-Information "px is already installed; skipping Scoop install."
@@ -448,7 +602,7 @@ function Start-PxProxy {
     $dir = Get-PxDataDir
     Start-Process -FilePath $exe -ArgumentList "--config=`"$configPath`"" -WorkingDirectory $dir -WindowStyle Hidden | Out-Null
 
-    Write-Information "px started (upstream $upstream). Listening on $script:PxEndpoint. Log: $dir\debug-*.log"
+    Write-Information "px started (upstream $upstream). Listening on $script:PxEndpoint. Tune settings in $(Get-PxUserConfigPath); logging is off unless you set log = 3 there (then logs land in $dir\debug-*.log)."
 }
 
 function Test-PxProxy {
@@ -466,7 +620,7 @@ function Test-PxProxy {
         [string]$Url = 'https://www.google.com'
     )
 
-    $logHint = "px log: $(Get-PxDataDir)\debug-*.log"
+    $logHint = "For a px log, set log = 3 in $(Get-PxUserConfigPath), re-run start, then read $(Get-PxDataDir)\debug-*.log."
 
     try {
         $response = Invoke-WebRequest -Uri $Url -Proxy $script:PxEndpoint -UseBasicParsing -TimeoutSec 20


### PR DESCRIPTION
## Summary

Started as the SC-045 branch, this PR bundles three related pieces of proxy/WSL work:

1. **SC-045**: the `setup-proxy` mode prompt now accepts Enter as Auto.
2. **SC-046** (new feature): px `[settings]` (log/workers/threads/idle/socktimeout) are user-configurable via a `px-user.ini` that survives config regeneration.
3. **Documentation sync**: corrected WSL Manager / px docs that had drifted after the SC-042/SC-043/SC-040/SC-016 work.

## SC-046: user-configurable px settings

- New user-owned `%USERPROFILE%\.config\px\px-user.ini`, merged into the generated `px.ini` on every `start`. Never overwritten, preserved on `remove`, seeded as a commented template on `install`/`start`.
- Only the `[settings]` block is read; managed keys (`server`/`listen`/`port`) are stripped, so nothing in the user file can move the `127.0.0.1:3128` contract or the resolved upstream.
- Default `log` flipped to `0` (opt-in logging); the `start`/`test` messages and the runbook explain how to enable it.
- New helpers: `Get-PxUserConfigPath`, `Get-PxUserSetting`, `Get-PxDefaultSetting`, `New-PxUserConfigTemplate`. Parser ignores blank lines, `#`/`;` comments, inline comments, and non-`[settings]` keys.

## SC-045: setup-proxy Enter defaults to Auto

- The mode prompt migrates from a raw `Read-Host`/`switch` to `Get-UserChoice` with `-defaultOption 'Auto'`, so Enter selects Auto and invalid input re-prompts (consistent with the sibling prompts).

## Documentation sync

- **SC-042/SC-043**: fixed stale `~/.profile` references (proxy env now lives in `/etc/profile.d` + `/etc/zsh/zshenv`) in both `docs/wsl-manager.md` and the C4 architecture doc, and documented the CA trust-store handling.
- **SC-040**: refreshed the WSL Manager module-structure tree (relocated integration tests, added missing modules/scripts, fixed `install.ps1`/`ops.ps1` descriptions).
- **SC-016**: marked shipped TUI components (menu, table) as done in the C4 doc while keeping SC-016d/e planned.
- px-proxy runbook gains a "Customizing settings" section.

## Testing

- px-proxy unit tests: 73/73.
- Full unit suite: 1111 passed, 17 failed, 1 skipped. The 17 are the pre-existing environmental `setup-user` failures (green in CI, unchanged from `develop`); the skip is the px entry-point test self-skipping when a real px is running locally. No new failures.
- PSScriptAnalyzer clean on the changed files.
- SC-045 and SC-046 UAT steps all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
