### PR TITLE
feat(scoop): resilient looping 5.1 update helper (SC-047)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,11 @@ jobs:
           Write-Host "==> Debug: GITHUB_ENV content:"
           Get-Content $Env:GITHUB_ENV -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "  $_" }
 
+      - name: Scoop lib 5.1 smoke guard
+        shell: powershell # Windows PowerShell 5.1 - enforces ADR 0001 (scoop/utils lib stay 5.1-compatible)
+        run: |
+          Set-Location $Env:SHORTCUTS_DIR; .\test\bin\smoke-ps51.ps1
+
       - name: Install test dependencies
         shell: pwsh
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,8 @@ tools/wsl-manager/
 
 ## Backlog Lifecycle
 
+**A backlog item is the single canonical artifact for a unit of work, and it MUST exist before any design or implementation begins.** If work is requested for which no backlog item exists, create the item first (next `SC-###`, status **Open** or **In Progress**, added to the README index) and capture the design *in that item* (Summary, Description, Scope Decisions, Acceptance Criteria, UAT Procedure). Do NOT create a separate design/spec document that duplicates the backlog item; the backlog item is the design of record. Reserve standalone design docs (e.g. under `docs/architecture/`) for genuinely large, multi-item efforts (epics), and link them from the item rather than duplicating its acceptance criteria.
+
 When starting work on a backlog item, update its status to **In Progress** and move it in the README index before committing implementation changes. When a subtask or the full item is completed, update status accordingly per the closing checklist in `docs/backlog/README.md`. Backlog updates are part of the implementation commit, not a separate afterthought.
 
 ## Coding Guidelines

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ It provides both a TUI (menu-driven interface) and CLI commands to:
 
 - **[Flow Launcher](docs/runbooks/flow-launcher-setup.md)**: A modern, actively maintained alternative launcher to Keypirinha with plugin support and auto-reload
 - **[px Proxy](docs/runbooks/px-proxy.md)**: A Windows-side local authenticating proxy (px) that gives native CLI tools and WSL seamless SSPI/Kerberos auth through the corporate proxy, with no stored credentials
+- **[Scoop Update Helper](docs/runbooks/scoop-update.md)**: An interactive, resilient loop for updating Scoop apps; runs under Windows PowerShell 5.1 in a classic console so it can update pwsh and Windows Terminal
 
 ---
 
@@ -369,6 +370,7 @@ Manually delete these folders if desired:
 ### Documentation
 
 - **[Development Principles](docs/development-principles.md)**: Coding standards, TDD approach, and project conventions
+- **[Architecture](docs/architecture/README.md)**: Diagrams and Architecture Decision Records (ADRs)
 - **[Roadmap](docs/roadmap.md)**: Project vision and future direction
 - **[Backlog](docs/backlog/README.md)**: Current work items, priorities, and completed features
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,17 @@
+[← Back to README](../../README.md)
+
+# Architecture
+
+Architecture documentation for the Shortcuts project.
+
+## Diagrams
+
+- [WSL Manager - C4 Architecture](wsl-manager-c4.md): Context, Container, and Component views of the WSL Manager.
+
+## Architecture Decision Records (ADR)
+
+Records of significant architectural decisions, their context, and consequences.
+
+- [ADR 0001: Scoop and utils libraries stay Windows PowerShell 5.1-compatible](adr/0001-lib-powershell-5.1-compatibility.md)
+
+[← Back to README](../../README.md)

--- a/docs/architecture/adr/0001-lib-powershell-5.1-compatibility.md
+++ b/docs/architecture/adr/0001-lib-powershell-5.1-compatibility.md
@@ -1,0 +1,32 @@
+[← Back to Architecture](../README.md)
+
+# ADR 0001: Scoop and utils libraries stay Windows PowerShell 5.1-compatible
+
+**Status**: Accepted (2026-07-24)
+**Context item**: [SC-047](../../backlog/sc-047.md)
+
+## Context
+
+The project targets PowerShell 7.4+ for library code (`lib/`), with only the bootstrap scripts kept 5.1-compatible. The Scoop update helper (`tools/scoop/update-scoop.ps1`), however, must run under **Windows PowerShell 5.1** in a classic console:
+
+- Updating `pwsh` itself fails while `pwsh.exe` is the running host (the executable is file-locked). Running the helper under `powershell.exe` (5.1) leaves `pwsh.exe` free to be replaced.
+- Updating Windows Terminal fails while it is the running console host. Launching the helper in a classic `conhost.exe` window (see `update-scoop.bat`) avoids locking `WindowsTerminal.exe`.
+
+The helper keeps its logic in `lib/scoop/scoop.ps1`, which dot-sources `lib/utils/utils.ps1`. Both files are therefore executed under 5.1 as well as 7.4+.
+
+A `#Requires -Version 5.1` line was considered and rejected: `#Requires` is a version *floor* and checks only the running engine version, not the syntax used, so it cannot catch a PS7-only construct (e.g. `??`, ternary, `-Parallel`) that fails only at runtime under 5.1. It would add nothing over this ADR plus a real CI check.
+
+## Decision
+
+`lib/scoop/scoop.ps1` and `lib/utils/utils.ps1` **MUST remain Windows PowerShell 5.1-compatible**. Any change to these two files (or code they newly depend on) must avoid PowerShell 7-only language features and cmdlets.
+
+This is enforced by a CI smoke guard, `test/bin/smoke-ps51.ps1`, run under `shell: powershell` (5.1) in `.github/workflows/test.yml`. It dot-sources both files under 5.1 (so any PS7-only parse/load regression fails the build), asserts the key functions are defined, and validates `Get-ScoopUpdatableApp` parsing via a shadow-stubbed `Invoke-CommandLine`. It is dependency-free (no Pester under 5.1) and fast.
+
+## Consequences
+
+- Contributors editing `scoop.ps1` or `utils.ps1` must stay within the 5.1 language/cmdlet subset; the CI smoke guard will fail otherwise.
+- The constraint is scoped to these two files only. The rest of `lib/` remains 7.4+.
+- If a future feature genuinely needs a PS7-only construct in `utils.ps1`, that shared code must be factored so the 5.1 consumer (the Scoop helper) does not load it, or this ADR must be revisited.
+- The full Pester suite still runs under pwsh 7.x; the 5.1 guard is an additional, lightweight gate, not a second test suite.
+
+[← Back to Architecture](../README.md)

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -15,6 +15,7 @@
 
 - [SC-001 — Backlog refinement](sc-001.md)
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
+- [SC-047 — Resilient, looping, 5.1-compatible Scoop update helper](sc-047.md)
 
 ### Open
 

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -15,7 +15,6 @@
 
 - [SC-001 — Backlog refinement](sc-001.md)
 - [SC-016 — Modernize WSL Manager TUI with PwshSpectreConsole](sc-016.md)
-- [SC-047 — Resilient, looping, 5.1-compatible Scoop update helper](sc-047.md)
 
 ### Open
 
@@ -41,6 +40,7 @@
 
 - [SC-049 — px unit tests must never kill a real px process](sc-049.md)
 - [SC-048 — Stable px defaults for sharing (workers = 1, idle = 300)](sc-048.md)
+- [SC-047 — Resilient, looping, 5.1-compatible Scoop update helper](sc-047.md)
 - [SC-046 — Make px `[settings]` user-configurable via px-user.ini](sc-046.md)
 - [SC-045 — Setup-proxy mode prompt: Enter defaults to Auto](sc-045.md)
 - [SC-036 — Corporate proxy for WSL without stored credentials](sc-036.md)

--- a/docs/backlog/sc-047.md
+++ b/docs/backlog/sc-047.md
@@ -1,0 +1,91 @@
+[← Back to Backlog](README.md)
+
+# [SC-047] Resilient, looping, 5.1-compatible Scoop update helper
+
+**Status**: In Progress
+**Priority**: Medium
+**Component**: `tools/scoop/update-scoop.ps1`, `tools/scoop/update-scoop.bat`, `lib/scoop/scoop.ps1`, `lib/scoop/scoop.Tests.ps1`, `test/bin/smoke-ps51.ps1`, `.github/workflows/test.yml`, `docs/architecture/adr/0001-lib-powershell-5.1-compatibility.md`, `docs/runbooks/scoop-update.md`, `README.md`
+**Related**: [SC-009](sc-009.md) (lint guard)
+
+**Summary**:
+As a developer maintaining my Scoop-managed tools, I want the Scoop update helper to keep running through Scoop errors, loop until I quit, and run under Windows PowerShell 5.1 in a plain console, so that I can update every app (including `pwsh` and Windows Terminal) in one session without the tool crashing or locking the very executables it is updating.
+
+**Description**:
+The current helper has three defects:
+
+1. It can crash/exit when Scoop fails, instead of showing the error and continuing.
+2. It runs once and exits; retrying or re-checking means relaunching.
+3. It runs under `pwsh` (PowerShell 7) via the `.bat` wrapper and declares `#Requires -Version 7.4`. That makes it impossible to update `pwsh` itself (the running `pwsh.exe` is file-locked) or Windows Terminal (locked while its host process runs).
+
+The fix makes the helper (a) resilient to Scoop failures, (b) loop until `Q`, and (c) run under Windows PowerShell 5.1 in a classic conhost window, so `pwsh` and Windows Terminal can be updated while it runs. All logic stays in `lib/scoop/scoop.ps1` (dot-sourcing `lib/utils/utils.ps1`); both lib files are already free of PS7-only syntax and must remain 5.1-compatible.
+
+**Scope Decisions**:
+
+- **Keep the shared lib; guard 5.1 compatibility (not a self-contained duplicate)**. The helper keeps dot-sourcing `lib/scoop/scoop.ps1` + `lib/utils/utils.ps1` (DRY). Silent regressions are prevented by (a) **ADR 0001** recording that these two files MUST stay Windows PowerShell 5.1-compatible, and (b) a lightweight CI smoke guard. A `#Requires -Version 5.1` line is deliberately NOT added: it is only a version floor and checks the running engine, not the syntax, so it would add nothing over the ADR + CI guard.
+
+- **CI 5.1 smoke guard = lightweight script (not full Pester under 5.1)**. `test/bin/smoke-ps51.ps1` runs under `shell: powershell` (5.1) in CI. It dot-sources both lib files (any PS7-only construct fails to parse/load → build fails), asserts the key functions are defined, and exercises the pure parsing logic of `Get-ScoopUpdatableApp` by shadow-stubbing `Invoke-CommandLine` with a function returning canned `scoop status` output (both modern PSCustomObject and legacy text forms). Dependency-free and fast; no Pester install under 5.1.
+
+- **Launch model = force detached classic console + Windows PowerShell 5.1**. `update-scoop.bat` becomes:
+  ```bat
+  @echo off
+  start "Scoop Update" conhost.exe powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0update-scoop.ps1" %*
+  ```
+  `conhost.exe` forces the classic console host, bypassing the Windows 11 "Windows Terminal is my default terminal application" setting (which would otherwise reopen `powershell.exe` inside Windows Terminal and re-lock it). `powershell.exe` is 5.1, so `pwsh.exe` is not the running host and can be updated. `start` detaches, so behavior is identical from Keypirinha, a Windows Terminal tab, or a double-click. `-NoProfile` for a clean, fast start (Scoop shims come from `PATH`, not the profile).
+
+- **Loop controller replaces one-shot flow**. `Invoke-ScoopUpdate` becomes a loop controller:
+  ```
+  header → check scoop installed (missing → error + return)
+  scoop update                       # bucket refresh, ONCE at startup
+  loop:
+      apps = Get-ScoopUpdatableApp   # scoop status (fast), each iteration
+      if apps empty:  choice = menu [R]efresh / [Q]uit  ("All apps up to date")
+      else:           Show-ScoopUpdatableApp; choice = menu numbers / [A]ll / [R]efresh / [Q]uit
+      switch choice.Action:
+          'update'  -> Update-ScoopApp; "Press any key to continue..."   # keypress before re-list
+          'refresh' -> scoop update                                       # bucket refresh
+          'quit'    -> break
+  ```
+  Bucket refresh (`scoop update`) runs once at startup and thereafter only on explicit `R`; each iteration re-runs the fast `scoop status`. After an update completes, a keypress pauses so the user can read output before the list is redrawn (re-list is not automatic). When nothing is updatable, the menu still offers `[R]efresh`/`[Q]uit` so the user is not kicked out (close a locked app → `R` → retry).
+
+- **New `Read-ScoopMenuChoice` replaces `Select-ScoopApp`** (singular noun, PSSA-clean). Returns a structured action `@{ Action = 'update' | 'refresh' | 'quit'; Apps = @(...) }`:
+
+  | Input | Result |
+  |-------|--------|
+  | `A` / `a` | `update`, all apps |
+  | `1,3` | `update`, selected apps |
+  | `R` / `r` | `refresh` |
+  | `Q` / `q` | `quit` |
+  | empty / all-invalid | `update`, `Apps=@()` (controller warns "nothing selected", re-loops) |
+  | mixed valid/invalid numbers | valid selected, invalid warned |
+
+  `Get-ScoopUpdatableApp`, `Show-ScoopUpdatableApp`, `Update-ScoopApp` are retained unchanged.
+
+- **Error resilience**. The entry `update-scoop.ps1` drops `#Requires -Version 7.4` and removes the "press any key to exit" `finally` block (the loop owns exit; the between-update keypress owns the read-output pause), keeping a thin top-level `try/catch`. Each loop-iteration body is wrapped in `try/catch` that prints via `Write-ErrorMsg` and returns to the menu. Scoop calls keep `-StopAtError $false`. Net workflow for locked files (Windows Terminal / pwsh open): update fails → error in red → back at menu → close the app → `R` → retry, all in one 5.1 conhost session.
+
+- **CI infinite-loop guard**. When `Test-RunningInCIorTestEnvironment` is `$true`, the controller performs exactly one update-all pass and returns (preserves today's CI behavior; never blocks on `Read-Host`; never loops forever).
+
+**Acceptance Criteria**:
+
+- [ ] `update-scoop.bat` launches the helper in a classic conhost window under Windows PowerShell 5.1, even when Windows Terminal is the default terminal application
+- [ ] `update-scoop.ps1` no longer declares `#Requires -Version 7.4` and no longer has an exit keypress; it keeps a thin top-level `try/catch`
+- [ ] `Invoke-ScoopUpdate` runs `scoop update` (bucket refresh) exactly once at startup, then loops on `scoop status`
+- [ ] `Read-ScoopMenuChoice` returns `@{Action;Apps}` per the table above: `A`/`a`→update-all; comma numbers→update-selected; `R`/`r`→refresh; `Q`/`q`→quit; empty→update with empty apps; out-of-range/non-numeric warned; mixed valid/invalid handled
+- [ ] A Scoop failure inside a loop iteration is caught, printed via `Write-ErrorMsg`, and the loop continues (session does not exit)
+- [ ] `R` triggers a bucket refresh; number(s)/`A` update the selected apps; a keypress pauses before the list is redrawn; `Q` exits the loop
+- [ ] When no apps are updatable, the menu offers `[R]efresh`/`[Q]uit` (user is not kicked out)
+- [ ] In CI (`Test-RunningInCIorTestEnvironment` true) the controller does exactly one update-all pass and never calls `Read-Host`
+- [ ] `lib/scoop/scoop.ps1` and `lib/utils/utils.ps1` load and run under Windows PowerShell 5.1
+- [ ] `test/bin/smoke-ps51.ps1` dot-sources both lib files under 5.1, asserts key functions exist, and validates `Get-ScoopUpdatableApp` parsing (modern + legacy) via a shadow-stubbed `Invoke-CommandLine`; a new `.github/workflows/test.yml` step (`shell: powershell`) runs it and fails the build on non-zero exit
+- [ ] ADR `docs/architecture/adr/0001-lib-powershell-5.1-compatibility.md` exists (Context/Decision/Consequences) and is linked from `docs/architecture/`
+- [ ] `docs/runbooks/scoop-update.md` documents purpose, why 5.1 + classic console, launch from Keypirinha, the menu, the pwsh/Windows Terminal update workflow, and troubleshooting; `README.md` More Features section links to it
+- [ ] `scoop.Tests.ps1` covers `Read-ScoopMenuChoice`, the loop controller (startup refresh once, re-list per iteration, `R` refresh, `Q` exit), the CI single-pass path, and per-iteration error resilience; changed-area unit tests green with no new failures
+
+**UAT Procedure**:
+
+1. [ ] With Windows Terminal set as the default terminal application, launch `update-scoop` from Keypirinha; confirm it opens a **classic** console window (not a Windows Terminal tab) running Windows PowerShell 5.1.
+2. [ ] With an updatable app available, select it by number; confirm it updates, a "press any key" pause appears, and the list is redrawn afterwards.
+3. [ ] With a Windows Terminal window open, attempt to update `windows-terminal`; confirm the failure is shown in red and the helper returns to the menu (does not exit). Close Windows Terminal, press `R`, retry; confirm it updates.
+4. [ ] Attempt to update `pwsh` from the 5.1 session; confirm it succeeds (no file-lock error).
+5. [ ] Press `R`; confirm a bucket refresh runs and the list is re-checked. Press `Q`; confirm the helper exits and the window closes.
+
+[← Back to Backlog](README.md)

--- a/docs/backlog/sc-047.md
+++ b/docs/backlog/sc-047.md
@@ -1,8 +1,8 @@
 [← Back to Backlog](README.md)
 
-# [SC-047] Resilient, looping, 5.1-compatible Scoop update helper
+# [SC-047] ✅ DONE - Resilient, looping, 5.1-compatible Scoop update helper
 
-**Status**: In Progress
+**Status**: Done (2026-07-24)
 **Priority**: Medium
 **Component**: `tools/scoop/update-scoop.ps1`, `tools/scoop/update-scoop.bat`, `lib/scoop/scoop.ps1`, `lib/scoop/scoop.Tests.ps1`, `test/bin/smoke-ps51.ps1`, `.github/workflows/test.yml`, `docs/architecture/adr/0001-lib-powershell-5.1-compatibility.md`, `docs/runbooks/scoop-update.md`, `README.md`
 **Related**: [SC-009](sc-009.md) (lint guard)
@@ -28,9 +28,9 @@ The fix makes the helper (a) resilient to Scoop failures, (b) loop until `Q`, an
 - **Launch model = force detached classic console + Windows PowerShell 5.1**. `update-scoop.bat` becomes:
   ```bat
   @echo off
-  start "Scoop Update" conhost.exe powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0update-scoop.ps1" %*
+  start "Scoop Update" conhost.exe powershell.exe -ExecutionPolicy Bypass -File "%~dp0update-scoop.ps1" %*
   ```
-  `conhost.exe` forces the classic console host, bypassing the Windows 11 "Windows Terminal is my default terminal application" setting (which would otherwise reopen `powershell.exe` inside Windows Terminal and re-lock it). `powershell.exe` is 5.1, so `pwsh.exe` is not the running host and can be updated. `start` detaches, so behavior is identical from Keypirinha, a Windows Terminal tab, or a double-click. `-NoProfile` for a clean, fast start (Scoop shims come from `PATH`, not the profile).
+  `conhost.exe` forces the classic console host, bypassing the Windows 11 "Windows Terminal is my default terminal application" setting (which would otherwise reopen `powershell.exe` inside Windows Terminal and re-lock it). `powershell.exe` is 5.1, so `pwsh.exe` is not the running host and can be updated. `start` detaches, so behavior is identical from Keypirinha, a Windows Terminal tab, or a double-click. The profile IS loaded (no `-NoProfile`): on corporate machines the user profile injects proxy configuration (`setProxy.ps1`) that Scoop needs to reach the internet, so suppressing it breaks downloads.
 
 - **Loop controller replaces one-shot flow**. `Invoke-ScoopUpdate` becomes a loop controller:
   ```
@@ -62,23 +62,26 @@ The fix makes the helper (a) resilient to Scoop failures, (b) loop until `Q`, an
 
 - **Error resilience**. The entry `update-scoop.ps1` drops `#Requires -Version 7.4` and removes the "press any key to exit" `finally` block (the loop owns exit; the between-update keypress owns the read-output pause), keeping a thin top-level `try/catch`. Each loop-iteration body is wrapped in `try/catch` that prints via `Write-ErrorMsg` and returns to the menu. Scoop calls keep `-StopAtError $false`. Net workflow for locked files (Windows Terminal / pwsh open): update fails → error in red → back at menu → close the app → `R` → retry, all in one 5.1 conhost session.
 
+- **Keypress pause is testable via a console seam**. `$Host` is a read-only automatic variable and cannot be shadowed, so `Wait-ScoopKeyPress` cannot be unit-tested while it calls `$Host.UI.RawUI.ReadKey(...)` directly (a test would block on a real key press, hanging CI). The lookup moves into a thin `Get-ScoopHostRawUi` seam that tests mock with a stub raw UI, mirroring `Read-SingleKey` in `tools/proxy/px-proxy.ps1`. The pause additionally returns early in CI/test environments and tolerates hosts with no interactive console (best-effort read, never fatal).
+
 - **CI infinite-loop guard**. When `Test-RunningInCIorTestEnvironment` is `$true`, the controller performs exactly one update-all pass and returns (preserves today's CI behavior; never blocks on `Read-Host`; never loops forever).
 
 **Acceptance Criteria**:
 
-- [ ] `update-scoop.bat` launches the helper in a classic conhost window under Windows PowerShell 5.1, even when Windows Terminal is the default terminal application
-- [ ] `update-scoop.ps1` no longer declares `#Requires -Version 7.4` and no longer has an exit keypress; it keeps a thin top-level `try/catch`
-- [ ] `Invoke-ScoopUpdate` runs `scoop update` (bucket refresh) exactly once at startup, then loops on `scoop status`
-- [ ] `Read-ScoopMenuChoice` returns `@{Action;Apps}` per the table above: `A`/`a`→update-all; comma numbers→update-selected; `R`/`r`→refresh; `Q`/`q`→quit; empty→update with empty apps; out-of-range/non-numeric warned; mixed valid/invalid handled
-- [ ] A Scoop failure inside a loop iteration is caught, printed via `Write-ErrorMsg`, and the loop continues (session does not exit)
-- [ ] `R` triggers a bucket refresh; number(s)/`A` update the selected apps; a keypress pauses before the list is redrawn; `Q` exits the loop
-- [ ] When no apps are updatable, the menu offers `[R]efresh`/`[Q]uit` (user is not kicked out)
-- [ ] In CI (`Test-RunningInCIorTestEnvironment` true) the controller does exactly one update-all pass and never calls `Read-Host`
-- [ ] `lib/scoop/scoop.ps1` and `lib/utils/utils.ps1` load and run under Windows PowerShell 5.1
-- [ ] `test/bin/smoke-ps51.ps1` dot-sources both lib files under 5.1, asserts key functions exist, and validates `Get-ScoopUpdatableApp` parsing (modern + legacy) via a shadow-stubbed `Invoke-CommandLine`; a new `.github/workflows/test.yml` step (`shell: powershell`) runs it and fails the build on non-zero exit
-- [ ] ADR `docs/architecture/adr/0001-lib-powershell-5.1-compatibility.md` exists (Context/Decision/Consequences) and is linked from `docs/architecture/`
-- [ ] `docs/runbooks/scoop-update.md` documents purpose, why 5.1 + classic console, launch from Keypirinha, the menu, the pwsh/Windows Terminal update workflow, and troubleshooting; `README.md` More Features section links to it
-- [ ] `scoop.Tests.ps1` covers `Read-ScoopMenuChoice`, the loop controller (startup refresh once, re-list per iteration, `R` refresh, `Q` exit), the CI single-pass path, and per-iteration error resilience; changed-area unit tests green with no new failures
+- [x] `update-scoop.bat` launches the helper in a classic conhost window under Windows PowerShell 5.1, even when Windows Terminal is the default terminal application
+- [x] `update-scoop.ps1` no longer declares `#Requires -Version 7.4` and no longer has an exit keypress; it keeps a thin top-level `try/catch`
+- [x] `Invoke-ScoopUpdate` runs `scoop update` (bucket refresh) exactly once at startup, then loops on `scoop status`
+- [x] `Read-ScoopMenuChoice` returns `@{Action;Apps}` per the table above: `A`/`a`→update-all; comma numbers→update-selected; `R`/`r`→refresh; `Q`/`q`→quit; empty→update with empty apps; out-of-range/non-numeric warned; mixed valid/invalid handled
+- [x] A Scoop failure inside a loop iteration is caught, printed via `Write-ErrorMsg`, and the loop continues (session does not exit)
+- [x] `R` triggers a bucket refresh; number(s)/`A` update the selected apps; a keypress pauses before the list is redrawn; `Q` exits the loop
+- [x] When no apps are updatable, the menu offers `[R]efresh`/`[Q]uit` (user is not kicked out)
+- [x] In CI (`Test-RunningInCIorTestEnvironment` true) the controller does exactly one update-all pass and never calls `Read-Host`
+- [x] `lib/scoop/scoop.ps1` and `lib/utils/utils.ps1` load and run under Windows PowerShell 5.1
+- [x] `test/bin/smoke-ps51.ps1` dot-sources both lib files under 5.1, asserts key functions exist, and validates `Get-ScoopUpdatableApp` parsing (modern + legacy) via a shadow-stubbed `Invoke-CommandLine`; a new `.github/workflows/test.yml` step (`shell: powershell`) runs it and fails the build on non-zero exit
+- [x] ADR `docs/architecture/adr/0001-lib-powershell-5.1-compatibility.md` exists (Context/Decision/Consequences) and is linked from `docs/architecture/`
+- [x] `docs/runbooks/scoop-update.md` documents purpose, why 5.1 + classic console, launch from Keypirinha, the menu, the pwsh/Windows Terminal update workflow, and troubleshooting; `README.md` More Features section links to it
+- [x] `scoop.Tests.ps1` covers `Read-ScoopMenuChoice`, the loop controller (startup refresh once, re-list per iteration, `R` refresh, `Q` exit), the CI single-pass path, and per-iteration error resilience; changed-area unit tests green with no new failures
+- [x] `Wait-ScoopKeyPress` is unit-tested through the mockable `Get-ScoopHostRawUi` seam (prompt + single `NoEcho,IncludeKeyDown` read when interactive, skipped in CI/test, no throw when the host has no console); `lib/scoop/scoop.ps1` has no uncovered lines and `smoke-ps51.ps1` asserts the new seam is defined under 5.1
 
 **UAT Procedure**:
 

--- a/docs/development-principles.md
+++ b/docs/development-principles.md
@@ -103,6 +103,7 @@ This document defines the core principles for developing the Shortcuts project. 
 
 **All code changes MUST follow this workflow:**
 
+0. **Create Backlog Item (if none exists)**: A backlog item is the single canonical artifact for a unit of work and MUST exist before any design or implementation. If none exists, create it first (next `SC-###`, added to the README index) and capture the design *in the item itself* (Summary, Description, Scope Decisions, Acceptance Criteria, UAT). Do NOT create a separate spec/design document that duplicates the item.
 1. **Update Backlog (Start)**: Move the backlog item to IN PROGRESS and check off any acceptance criteria that are already met
 2. **Research**: Check if functionality exists in `lib/` or other scripts
 3. **Design**: Plan the script structure and identify reusable components

--- a/docs/runbooks/scoop-update.md
+++ b/docs/runbooks/scoop-update.md
@@ -1,0 +1,80 @@
+[← Back to README](../../README.md)
+
+# Scoop Update Helper Runbook
+
+## Overview
+
+`update-scoop` is an interactive helper for updating your [Scoop](https://scoop.sh)-managed apps. It refreshes Scoop once, then loops: it lists the apps that have updates, lets you pick which to update (or all), and stays open so you can update, re-check, and retry without relaunching. You leave the loop by pressing `Q`.
+
+It is built around three properties:
+
+- **Resilient**: if a Scoop command fails (for example, an app is locked), the error is shown and you are returned to the menu. The session never crashes or exits on a Scoop error.
+- **Looping**: it runs until you quit, so you can update several apps, close a locked application, and retry in one sitting.
+- **Runs under Windows PowerShell 5.1 in a classic console**: this is what lets it update `pwsh` and Windows Terminal (see below).
+
+**Why 5.1 and a classic console:** a program cannot replace its own running executable. If the helper ran under `pwsh` (PowerShell 7), updating `pwsh` would fail because `pwsh.exe` is locked; if it ran inside Windows Terminal, updating Windows Terminal would fail because `WindowsTerminal.exe` is locked. So `update-scoop.bat` launches the helper under `powershell.exe` (Windows PowerShell 5.1) inside a classic `conhost` window, detached from wherever you started it. `conhost.exe` is used explicitly so that even if Windows Terminal is set as your default terminal application, the helper still opens in a classic console rather than a Windows Terminal tab.
+
+**When to use it:** whenever you want to update Scoop apps interactively, and especially when you need to update `pwsh` or Windows Terminal, which cannot be updated from a normal PowerShell 7 / Windows Terminal session.
+
+---
+
+## Prerequisites
+
+- [Scoop](https://scoop.sh) installed. The helper checks for it and exits with a message if it is missing.
+- Nothing else: the helper uses only Windows PowerShell 5.1, which ships with Windows.
+
+---
+
+## Usage
+
+Run from Keypirinha (type `update-scoop`) or from a terminal:
+
+```bat
+tools\scoop\update-scoop.bat
+```
+
+Always launch via the `.bat` wrapper (not `update-scoop.ps1` directly): the wrapper is what forces the classic console + Windows PowerShell 5.1 that makes `pwsh` / Windows Terminal updates possible.
+
+A new console window opens with the menu:
+
+```text
+Updatable Apps:
+  1. pwsh              (7.5.4 -> 7.5.5)
+  2. windows-terminal  (1.19  -> 1.20)
+
+Enter number(s) comma-separated, [A]ll, [R]efresh, [Q]uit:
+```
+
+| Input | What it does |
+|-------|--------------|
+| `1` or `1,3` | Updates the numbered app(s). |
+| `A` | Updates all listed apps. |
+| `R` | Re-runs the Scoop bucket refresh and re-checks for updates. |
+| `Q` | Quits and closes the window. |
+
+After an update runs, the helper pauses ("Press any key to continue...") so you can read the output before the list is redrawn. The bucket refresh (`scoop update`) runs once automatically at startup; use `R` to refresh again.
+
+### Updating pwsh or Windows Terminal
+
+Because the helper runs under Windows PowerShell 5.1 in a classic console:
+
+- **`pwsh`** can be updated directly: select it from the list.
+- **Windows Terminal** can only be replaced while no Windows Terminal window is open. If a Windows Terminal window is still running, the update fails, the error is shown in red, and you are returned to the menu. Close all Windows Terminal windows, press `R` to re-check, then update `windows-terminal`. All of this happens in the same helper session.
+
+---
+
+## Troubleshooting
+
+**It opened in a Windows Terminal tab, not a classic console.**
+Launch via `update-scoop.bat`, not `update-scoop.ps1`. The wrapper uses `conhost.exe` specifically to bypass the "Windows Terminal is my default terminal application" setting. If you invoked the `.ps1` directly (or copied only part of the wrapper command), you lose that behavior.
+
+**"Scoop is not installed."**
+Install Scoop first (see the [Scoop website](https://scoop.sh) or the project README), then re-run.
+
+**A `windows-terminal` update keeps failing.**
+A Windows Terminal window is still open (it does not have to be the one you launched from). Close every Windows Terminal window, press `R`, and retry. The helper itself runs in a classic console, so it does not block the update.
+
+**An update fails for some other reason.**
+The raw Scoop error is printed and you are returned to the menu; the session keeps running. Read the error, resolve the cause (for example a running process or a network/proxy issue), press `R` to re-check, and retry.
+
+[← Back to README](../../README.md)

--- a/lib/scoop/scoop.Tests.ps1
+++ b/lib/scoop/scoop.Tests.ps1
@@ -118,8 +118,9 @@ Describe 'Show-ScoopUpdatableApp' {
     }
 }
 
-Describe 'Select-ScoopApp' {
+Describe 'Read-ScoopMenuChoice' {
     BeforeEach {
+        Mock Write-WarningMsg {}
         $script:testApps = @(
             [PSCustomObject]@{ Name = '7zip'; InstalledVersion = '24.08'; LatestVersion = '24.09' }
             [PSCustomObject]@{ Name = 'git'; InstalledVersion = '2.46.0'; LatestVersion = '2.47.0' }
@@ -127,86 +128,177 @@ Describe 'Select-ScoopApp' {
         )
     }
 
-    Context 'In CI environment' {
-        It 'returns all app names' {
-            Mock Test-RunningInCIorTestEnvironment { return $true }
+    It 'returns update-all when user enters A' {
+        Mock Read-Host { return 'A' }
 
-            $result = @(Select-ScoopApp -Apps $script:testApps)
+        $result = Read-ScoopMenuChoice -Apps $script:testApps
 
-            $result.Count | Should -Be 3
-            $result | Should -Contain '7zip'
-            $result | Should -Contain 'git'
-            $result | Should -Contain 'pwsh'
+        $result.Action | Should -Be 'update'
+        @($result.Apps).Count | Should -Be 3
+    }
+
+    It 'returns update-all when user enters lowercase a' {
+        Mock Read-Host { return 'a' }
+
+        $result = Read-ScoopMenuChoice -Apps $script:testApps
+
+        $result.Action | Should -Be 'update'
+        @($result.Apps).Count | Should -Be 3
+    }
+
+    It 'returns selected apps by comma-separated numbers' {
+        Mock Read-Host { return '1,3' }
+
+        $result = Read-ScoopMenuChoice -Apps $script:testApps
+
+        $result.Action | Should -Be 'update'
+        @($result.Apps).Count | Should -Be 2
+        $result.Apps | Should -Contain '7zip'
+        $result.Apps | Should -Contain 'pwsh'
+    }
+
+    It 'returns refresh when user enters R' {
+        Mock Read-Host { return 'R' }
+
+        $result = Read-ScoopMenuChoice -Apps $script:testApps
+
+        $result.Action | Should -Be 'refresh'
+    }
+
+    It 'returns refresh when user enters lowercase r' {
+        Mock Read-Host { return 'r' }
+
+        $result = Read-ScoopMenuChoice -Apps $script:testApps
+
+        $result.Action | Should -Be 'refresh'
+    }
+
+    It 'returns quit when user enters Q' {
+        Mock Read-Host { return 'Q' }
+
+        $result = Read-ScoopMenuChoice -Apps $script:testApps
+
+        $result.Action | Should -Be 'quit'
+    }
+
+    It 'returns quit when user enters lowercase q' {
+        Mock Read-Host { return 'q' }
+
+        $result = Read-ScoopMenuChoice -Apps $script:testApps
+
+        $result.Action | Should -Be 'quit'
+    }
+
+    It 'returns refresh even when no apps are updatable' {
+        Mock Read-Host { return 'R' }
+
+        $result = Read-ScoopMenuChoice -Apps @()
+
+        $result.Action | Should -Be 'refresh'
+    }
+
+    It 'warns on out-of-range number and returns update with no apps' {
+        Mock Read-Host { return '5' }
+
+        $result = Read-ScoopMenuChoice -Apps $script:testApps
+
+        $result.Action | Should -Be 'update'
+        @($result.Apps).Count | Should -Be 0
+        Should -Invoke Write-WarningMsg -ParameterFilter { $Message -like '*Invalid number*' }
+    }
+
+    It 'warns on non-numeric input and returns update with no apps' {
+        Mock Read-Host { return 'xyz' }
+
+        $result = Read-ScoopMenuChoice -Apps $script:testApps
+
+        $result.Action | Should -Be 'update'
+        @($result.Apps).Count | Should -Be 0
+        Should -Invoke Write-WarningMsg -ParameterFilter { $Message -like '*Invalid input*' }
+    }
+
+    It 'handles mixed valid and invalid input' {
+        Mock Read-Host { return '1,abc,99' }
+
+        $result = Read-ScoopMenuChoice -Apps $script:testApps
+
+        $result.Action | Should -Be 'update'
+        @($result.Apps).Count | Should -Be 1
+        $result.Apps | Should -Contain '7zip'
+        Should -Invoke Write-WarningMsg -Times 2
+    }
+
+    It 'returns update with no apps on empty input' {
+        Mock Read-Host { return '' }
+
+        $result = Read-ScoopMenuChoice -Apps $script:testApps
+
+        $result.Action | Should -Be 'update'
+        @($result.Apps).Count | Should -Be 0
+    }
+}
+
+Describe 'Get-ScoopHostRawUi' {
+    It 'returns the raw UI of the current host' {
+        Get-ScoopHostRawUi | Should -Be $Host.UI.RawUI
+    }
+}
+
+Describe 'Wait-ScoopKeyPress' {
+    BeforeAll {
+        # Stub raw UI: records the ReadKey call on itself ($this), so no real
+        # console read happens and the test never blocks.
+        function Get-StubRawUi {
+            param([switch]$FailOnRead)
+
+            $stub = [PSCustomObject]@{
+                ReadKeyCalls   = 0
+                ReadKeyOptions = $null
+                FailOnRead     = [bool]$FailOnRead
+            }
+            $stub | Add-Member -MemberType ScriptMethod -Name ReadKey -Value {
+                param($Options)
+                $this.ReadKeyCalls++
+                $this.ReadKeyOptions = $Options
+                if ($this.FailOnRead) { throw 'The method or operation is not implemented.' }
+                return $null
+            }
+            return $stub
         }
     }
 
-    Context 'In interactive environment' {
-        BeforeEach {
-            Mock Test-RunningInCIorTestEnvironment { return $false }
-            Mock Write-WarningMsg {}
-        }
+    BeforeEach {
+        Mock Write-Host {}
+        # Default: interactive (not CI). CI-specific test overrides this.
+        Mock Test-RunningInCIorTestEnvironment { return $false }
+        $script:stubRawUi = Get-StubRawUi
+        Mock Get-ScoopHostRawUi { return $script:stubRawUi }
+    }
 
-        It 'returns all apps when user enters A' {
-            Mock Read-Host { return 'A' }
+    It 'prompts and reads a single key without echo when interactive' {
+        Wait-ScoopKeyPress
 
-            $result = @(Select-ScoopApp -Apps $script:testApps)
+        Should -Invoke Get-ScoopHostRawUi -Times 1
+        $script:stubRawUi.ReadKeyCalls | Should -Be 1
+        $script:stubRawUi.ReadKeyOptions | Should -Be 'NoEcho,IncludeKeyDown'
+        Should -Invoke Write-Host -ParameterFilter { $Object -eq 'Press any key to continue...' } -Times 1
+    }
 
-            $result.Count | Should -Be 3
-        }
+    It 'skips the key read in CI/test environments' {
+        Mock Test-RunningInCIorTestEnvironment { return $true }
 
-        It 'returns all apps when user enters lowercase a' {
-            Mock Read-Host { return 'a' }
+        Wait-ScoopKeyPress
 
-            $result = @(Select-ScoopApp -Apps $script:testApps)
+        Should -Invoke Get-ScoopHostRawUi -Times 0
+        Should -Invoke Write-Host -Times 0
+        $script:stubRawUi.ReadKeyCalls | Should -Be 0
+    }
 
-            $result.Count | Should -Be 3
-        }
+    It 'does not throw when the host has no interactive console' {
+        $script:stubRawUi = Get-StubRawUi -FailOnRead
 
-        It 'returns selected apps by comma-separated numbers' {
-            Mock Read-Host { return '1,3' }
-
-            $result = @(Select-ScoopApp -Apps $script:testApps)
-
-            $result.Count | Should -Be 2
-            $result | Should -Contain '7zip'
-            $result | Should -Contain 'pwsh'
-        }
-
-        It 'warns on out-of-range number' {
-            Mock Read-Host { return '5' }
-
-            $result = @(Select-ScoopApp -Apps $script:testApps)
-
-            $result.Count | Should -Be 0
-            Should -Invoke Write-WarningMsg -ParameterFilter { $Message -like '*Invalid number*' }
-        }
-
-        It 'warns on non-numeric input' {
-            Mock Read-Host { return 'xyz' }
-
-            $result = @(Select-ScoopApp -Apps $script:testApps)
-
-            $result.Count | Should -Be 0
-            Should -Invoke Write-WarningMsg -ParameterFilter { $Message -like '*Invalid input*' }
-        }
-
-        It 'handles mixed valid and invalid input' {
-            Mock Read-Host { return '1,abc,99' }
-
-            $result = @(Select-ScoopApp -Apps $script:testApps)
-
-            $result.Count | Should -Be 1
-            $result | Should -Contain '7zip'
-            Should -Invoke Write-WarningMsg -Times 2
-        }
-
-        It 'returns empty array on empty input' {
-            Mock Read-Host { return '' }
-
-            $result = @(Select-ScoopApp -Apps $script:testApps)
-
-            $result.Count | Should -Be 0
-        }
+        { Wait-ScoopKeyPress } | Should -Not -Throw
+        $script:stubRawUi.ReadKeyCalls | Should -Be 1
     }
 }
 
@@ -259,6 +351,14 @@ Describe 'Invoke-ScoopUpdate' {
         Mock Write-ErrorMsg {}
         Mock Invoke-CommandLine {}
         Mock Get-Command { return $true }
+        Mock Show-ScoopUpdatableApp {}
+        Mock Update-ScoopApp {}
+        Mock Wait-ScoopKeyPress {}
+        # Default: interactive (not CI). CI-specific test overrides this.
+        Mock Test-RunningInCIorTestEnvironment { return $false }
+        $script:oneApp = @(
+            [PSCustomObject]@{ Name = '7zip'; InstalledVersion = '24.08'; LatestVersion = '24.09' }
+        )
     }
 
     It 'shows error when scoop is not installed' {
@@ -269,48 +369,106 @@ Describe 'Invoke-ScoopUpdate' {
         Should -Invoke Write-ErrorMsg -ParameterFilter { $Message -like '*Scoop is not installed*' } -Times 1
     }
 
-    It 'refreshes scoop before checking for updates' {
+    It 'refreshes scoop exactly once at startup before the loop' {
         Mock Get-ScoopUpdatableApp { return @() }
+        Mock Read-ScoopMenuChoice { return @{ Action = 'quit'; Apps = @() } }
 
         Invoke-ScoopUpdate
 
         Should -Invoke Invoke-CommandLine -ParameterFilter { $CommandLine -eq 'scoop update' } -Times 1
     }
 
-    It 'shows up-to-date message when no updates available' {
+    It 'shows up-to-date message when no updates available then quits' {
         Mock Get-ScoopUpdatableApp { return @() }
+        Mock Read-ScoopMenuChoice { return @{ Action = 'quit'; Apps = @() } }
 
         Invoke-ScoopUpdate
 
         Should -Invoke Write-Success -ParameterFilter { $Message -like '*up to date*' } -Times 1
     }
 
-    It 'runs full update flow when apps are updatable' {
-        $apps = @(
-            [PSCustomObject]@{ Name = '7zip'; InstalledVersion = '24.08'; LatestVersion = '24.09' }
-        )
-        Mock Get-ScoopUpdatableApp { return $apps }
-        Mock Show-ScoopUpdatableApp {}
-        Mock Select-ScoopApp { return @('7zip') }
-        Mock Update-ScoopApp {}
+    It 'updates selected apps, pauses for a keypress, then loops until quit' {
+        Mock Get-ScoopUpdatableApp { return $script:oneApp }
+        $script:menuCalls = 0
+        Mock Read-ScoopMenuChoice {
+            $script:menuCalls++
+            if ($script:menuCalls -eq 1) { return @{ Action = 'update'; Apps = @('7zip') } }
+            return @{ Action = 'quit'; Apps = @() }
+        }
 
         Invoke-ScoopUpdate
 
-        Should -Invoke Show-ScoopUpdatableApp -Times 1
-        Should -Invoke Select-ScoopApp -Times 1
-        Should -Invoke Update-ScoopApp -Times 1
+        Should -Invoke Show-ScoopUpdatableApp -Times 2   # once per loop iteration (update, then quit)
+        Should -Invoke Update-ScoopApp -ParameterFilter { $AppNames -contains '7zip' } -Times 1
+        Should -Invoke Wait-ScoopKeyPress -Times 1
     }
 
-    It 'shows warning when no apps selected' {
-        $apps = @(
-            [PSCustomObject]@{ Name = '7zip'; InstalledVersion = '24.08'; LatestVersion = '24.09' }
-        )
-        Mock Get-ScoopUpdatableApp { return $apps }
-        Mock Show-ScoopUpdatableApp {}
-        Mock Select-ScoopApp { return @() }
+    It 'refresh action re-runs the bucket refresh' {
+        Mock Get-ScoopUpdatableApp { return @() }
+        $script:menuCalls = 0
+        Mock Read-ScoopMenuChoice {
+            $script:menuCalls++
+            if ($script:menuCalls -eq 1) { return @{ Action = 'refresh'; Apps = @() } }
+            return @{ Action = 'quit'; Apps = @() }
+        }
+
+        Invoke-ScoopUpdate
+
+        # startup refresh + one explicit refresh
+        Should -Invoke Invoke-CommandLine -ParameterFilter { $CommandLine -eq 'scoop update' } -Times 2
+    }
+
+    It 'warns when update chosen with no apps selected' {
+        Mock Get-ScoopUpdatableApp { return $script:oneApp }
+        $script:menuCalls = 0
+        Mock Read-ScoopMenuChoice {
+            $script:menuCalls++
+            if ($script:menuCalls -eq 1) { return @{ Action = 'update'; Apps = @() } }
+            return @{ Action = 'quit'; Apps = @() }
+        }
 
         Invoke-ScoopUpdate
 
         Should -Invoke Write-WarningMsg -ParameterFilter { $Message -like '*No apps selected*' } -Times 1
+        Should -Invoke Update-ScoopApp -Times 0
+    }
+
+    It 'catches an error inside an iteration and continues the loop' {
+        $script:statusCalls = 0
+        Mock Get-ScoopUpdatableApp {
+            $script:statusCalls++
+            if ($script:statusCalls -eq 1) { throw 'scoop exploded' }
+            return @()
+        }
+        Mock Read-ScoopMenuChoice { return @{ Action = 'quit'; Apps = @() } }
+
+        { Invoke-ScoopUpdate } | Should -Not -Throw
+        Should -Invoke Write-ErrorMsg -Times 1
+    }
+
+    Context 'In CI environment' {
+        It 'does exactly one update-all pass and never calls Read-Host' {
+            Mock Test-RunningInCIorTestEnvironment { return $true }
+            Mock Get-ScoopUpdatableApp { return $script:oneApp }
+            Mock Read-Host { return 'Q' }
+
+            Invoke-ScoopUpdate
+
+            Should -Invoke Update-ScoopApp -ParameterFilter { $AppNames -contains '7zip' } -Times 1
+            Should -Invoke Read-Host -Times 0
+        }
+
+        It 'reports everything up to date and returns without updating' {
+            Mock Test-RunningInCIorTestEnvironment { return $true }
+            Mock Get-ScoopUpdatableApp { return @() }
+            Mock Read-Host { return 'Q' }
+
+            Invoke-ScoopUpdate
+
+            Should -Invoke Write-Success -ParameterFilter { $Message -like '*up to date*' } -Times 1
+            Should -Invoke Show-ScoopUpdatableApp -Times 0
+            Should -Invoke Update-ScoopApp -Times 0
+            Should -Invoke Read-Host -Times 0
+        }
     }
 }

--- a/lib/scoop/scoop.ps1
+++ b/lib/scoop/scoop.ps1
@@ -105,42 +105,56 @@ function Show-ScoopUpdatableApp {
     Write-Host ""
 }
 
-function Select-ScoopApp {
+function Read-ScoopMenuChoice {
     <#
     .SYNOPSIS
-        Prompts the user to select apps to update.
+        Prompts for a menu choice and returns a structured action.
 
     .DESCRIPTION
-        Displays a selection prompt. User can enter 'A' for all, or
-        comma-separated numbers to select specific apps.
+        Reads a single interactive menu line and maps it to an action:
+        'update' (with the list of selected app names), 'refresh', or 'quit'.
+        Number(s) and 'A' are only meaningful when apps are updatable; when the
+        app list is empty only [R]efresh and [Q]uit are offered.
 
     .PARAMETER Apps
-        Array of app objects from Get-ScoopUpdatableApp.
+        Array of updatable app objects from Get-ScoopUpdatableApp. May be empty.
 
     .OUTPUTS
-        Array of app names selected for update.
+        Hashtable with keys:
+          Action - one of 'update', 'refresh', 'quit'
+          Apps   - array of selected app names (empty unless Action is 'update')
     #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [PSCustomObject[]]$Apps
     )
 
-    if (Test-RunningInCIorTestEnvironment) {
-        # In CI, update all by default
-        return @($Apps | ForEach-Object { $_.Name })
+    if ($Apps.Count -gt 0) {
+        $prompt = "Enter number(s) comma-separated, [A]ll, [R]efresh, [Q]uit"
+    }
+    else {
+        $prompt = "[R]efresh, [Q]uit"
     }
 
-    $selection = Read-Host "Enter app number(s) comma-separated, or [A] for all"
+    $selection = Read-Host $prompt
 
+    if ($selection -match '^[Qq]$') {
+        return @{ Action = 'quit'; Apps = @() }
+    }
+    if ($selection -match '^[Rr]$') {
+        return @{ Action = 'refresh'; Apps = @() }
+    }
     if ($selection -match '^[Aa]$') {
-        return @($Apps | ForEach-Object { $_.Name })
+        return @{ Action = 'update'; Apps = @($Apps | ForEach-Object { $_.Name }) }
     }
 
     $indices = $selection -split ',' | ForEach-Object { $_.Trim() }
     $selectedApps = @()
 
     foreach ($idx in $indices) {
+        if ([string]::IsNullOrWhiteSpace($idx)) { continue }
         if ($idx -match '^\d+$') {
             $num = [int]$idx
             if ($num -ge 1 -and $num -le $Apps.Count) {
@@ -151,11 +165,73 @@ function Select-ScoopApp {
             }
         }
         else {
-            Write-WarningMsg "Invalid input: '$idx' (enter numbers or 'A')"
+            Write-WarningMsg "Invalid input: '$idx' (enter numbers, 'A', 'R', or 'Q')"
         }
     }
 
-    return $selectedApps
+    return @{ Action = 'update'; Apps = $selectedApps }
+}
+
+function Get-ScoopHostRawUi {
+    <#
+    .SYNOPSIS
+        Returns the raw UI of the current host (thin, mockable console seam).
+
+    .DESCRIPTION
+        $Host is a read-only automatic variable and cannot be shadowed, so the
+        lookup is isolated here: tests mock this function to hand back a stub
+        raw UI and therefore never block on a real key press.
+    #>
+    [CmdletBinding()]
+    param()
+
+    return $Host.UI.RawUI
+}
+
+function Wait-ScoopKeyPress {
+    <#
+    .SYNOPSIS
+        Pauses until the user presses a key so command output can be read
+        before the menu is redrawn.
+
+    .DESCRIPTION
+        Skipped in CI/test environments (there is nothing to wait on, and a
+        blocking read would hang the build) and tolerant of hosts with no
+        interactive console: the read is best-effort, never fatal.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if (Test-RunningInCIorTestEnvironment) {
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Press any key to continue..."
+    try {
+        $null = (Get-ScoopHostRawUi).ReadKey("NoEcho,IncludeKeyDown")
+    }
+    catch {
+        # No interactive console (redirected input, non-interactive host):
+        # there is nothing to wait on, so continue without failing.
+        Write-Verbose "Key read skipped: $_"
+    }
+}
+
+function Invoke-ScoopBucketRefresh {
+    <#
+    .SYNOPSIS
+        Refreshes Scoop and its bucket metadata ('scoop update').
+
+    .DESCRIPTION
+        Non-fatal: a failure is logged and control continues, so the helper
+        never exits because a refresh failed.
+    #>
+    [CmdletBinding()]
+    param()
+
+    Write-Status "Refreshing Scoop..."
+    Invoke-CommandLine -CommandLine "scoop update" -StopAtError $false -PrintCommand $false
 }
 
 function Update-ScoopApp {
@@ -193,8 +269,15 @@ function Invoke-ScoopUpdate {
         Main entry point for the interactive Scoop update helper.
 
     .DESCRIPTION
-        Refreshes Scoop, checks for updatable apps, displays a numbered list,
-        and lets the user select which apps to update.
+        Refreshes Scoop once at startup, then loops: lists updatable apps and
+        lets the user select apps to update, refresh the buckets ('R'), or quit
+        ('Q'). Each iteration is resilient: a Scoop failure is printed and
+        control returns to the menu, so the session never exits on error. This
+        lets the user close a locked application (e.g. Windows Terminal or pwsh),
+        press 'R', and retry within the same session.
+
+        In CI / test environments (Test-RunningInCIorTestEnvironment) it performs
+        exactly one update-all pass and returns, so it never blocks on input.
     #>
     [CmdletBinding()]
     param()
@@ -210,36 +293,60 @@ function Invoke-ScoopUpdate {
         return
     }
 
-    # Refresh Scoop and bucket info
-    Write-Status "Refreshing Scoop..."
-    Invoke-CommandLine -CommandLine "scoop update" -StopAtError $false -PrintCommand $false
+    # Refresh Scoop and bucket info once at startup
+    Invoke-ScoopBucketRefresh
 
-    # Get updatable apps
-    $apps = @(Get-ScoopUpdatableApp)
-
-    if ($apps.Count -eq 0) {
-        Write-Success "All apps are up to date!"
+    if (Test-RunningInCIorTestEnvironment) {
+        # Non-interactive: single update-all pass, no prompts, no loop
+        $apps = @(Get-ScoopUpdatableApp)
+        if ($apps.Count -eq 0) {
+            Write-Success "All apps are up to date!"
+            return
+        }
+        Show-ScoopUpdatableApp -Apps $apps
+        Update-ScoopApp -AppNames @($apps | ForEach-Object { $_.Name })
+        Write-Success "Update complete!"
         return
     }
 
-    # Display updatable apps
-    Show-ScoopUpdatableApp -Apps $apps
+    # Interactive loop until the user quits
+    while ($true) {
+        try {
+            $apps = @(Get-ScoopUpdatableApp)
+            if ($apps.Count -eq 0) {
+                Write-Success "All apps are up to date!"
+            }
+            else {
+                Show-ScoopUpdatableApp -Apps $apps
+            }
 
-    # Select apps to update
-    $selectedApps = @(Select-ScoopApp -Apps $apps)
+            $choice = Read-ScoopMenuChoice -Apps $apps
 
-    if ($selectedApps.Count -eq 0) {
-        Write-WarningMsg "No apps selected for update."
-        return
+            switch ($choice.Action) {
+                'quit' {
+                    return
+                }
+                'refresh' {
+                    Invoke-ScoopBucketRefresh
+                }
+                'update' {
+                    if (@($choice.Apps).Count -eq 0) {
+                        Write-WarningMsg "No apps selected for update."
+                    }
+                    else {
+                        Write-Host ""
+                        Write-Status "Updating $(@($choice.Apps).Count) app(s)..."
+                        Write-Host ""
+                        Update-ScoopApp -AppNames $choice.Apps
+                        Write-Host ""
+                        Write-Success "Update complete!"
+                        Wait-ScoopKeyPress
+                    }
+                }
+            }
+        }
+        catch {
+            Write-ErrorMsg "Error: $_"
+        }
     }
-
-    Write-Host ""
-    Write-Status "Updating $($selectedApps.Count) app(s)..."
-    Write-Host ""
-
-    # Update selected apps
-    Update-ScoopApp -AppNames $selectedApps
-
-    Write-Host ""
-    Write-Success "Update complete!"
 }

--- a/test/bin/smoke-ps51.ps1
+++ b/test/bin/smoke-ps51.ps1
@@ -1,0 +1,92 @@
+﻿<#
+.SYNOPSIS
+    Windows PowerShell 5.1 compatibility smoke guard for the Scoop lib.
+
+.DESCRIPTION
+    Enforces docs/architecture/adr/0001-lib-powershell-5.1-compatibility.md.
+
+    Dot-sources lib/scoop/scoop.ps1 (which sources lib/utils/utils.ps1) under
+    Windows PowerShell 5.1, so any PS7-only construct fails to parse/load and the
+    build breaks. Then asserts the key functions are defined and validates
+    Get-ScoopUpdatableApp parsing (modern PSCustomObject and legacy text output)
+    by shadow-stubbing Invoke-CommandLine, so no real 'scoop status' is invoked.
+
+    Dependency-free (no Pester); exits non-zero on the first failure so CI fails.
+
+.NOTES
+    MUST run under Windows PowerShell 5.1 (shell: powershell), not pwsh.
+#>
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Join-Path $PSScriptRoot "..\.."
+$scoopLib = Join-Path $repoRoot "lib\scoop\scoop.ps1"
+
+Write-Output "==> PowerShell version: $($PSVersionTable.PSVersion)"
+if ($PSVersionTable.PSVersion.Major -ne 5) {
+    throw "smoke-ps51 must run under Windows PowerShell 5.1 (found $($PSVersionTable.PSVersion))"
+}
+
+# 1. Dot-source the lib under 5.1 - catches any PS7-only parse/load regression.
+. $scoopLib
+
+# 2. Assert the key functions are defined (scoop lib + a representative util).
+$expected = @(
+    'Get-ScoopUpdatableApp'
+    'Show-ScoopUpdatableApp'
+    'Read-ScoopMenuChoice'
+    'Get-ScoopHostRawUi'
+    'Wait-ScoopKeyPress'
+    'Invoke-ScoopBucketRefresh'
+    'Update-ScoopApp'
+    'Invoke-ScoopUpdate'
+    'Invoke-CommandLine'
+)
+foreach ($fn in $expected) {
+    if (-not (Get-Command $fn -ErrorAction SilentlyContinue)) {
+        throw "Expected function not defined after dot-sourcing under 5.1: $fn"
+    }
+}
+Write-Output "==> All expected functions defined under 5.1"
+
+# 3. Validate Get-ScoopUpdatableApp parsing via a shadow-stubbed Invoke-CommandLine.
+#    Redefining the function in this scope overrides the dot-sourced one for
+#    subsequent calls, so no real 'scoop status' runs.
+
+# Modern scoop: structured PSCustomObject output.
+function Invoke-CommandLine {
+    param($CommandLine, $StopAtError, $PrintCommand, $Silent)
+    $null = $CommandLine, $StopAtError, $PrintCommand, $Silent
+    return @(
+        [PSCustomObject]@{ Name = 'gimp'; 'Installed Version' = '3.0.8'; 'Latest Version' = '3.2.0' }
+        [PSCustomObject]@{ Name = 'pwsh'; 'Installed Version' = '7.5.4'; 'Latest Version' = '7.5.5' }
+    )
+}
+$modern = @(Get-ScoopUpdatableApp)
+if ($modern.Count -ne 2) { throw "Modern parse: expected 2 apps, got $($modern.Count)" }
+if ($modern[0].Name -ne 'gimp' -or $modern[0].LatestVersion -ne '3.2.0') { throw "Modern parse: unexpected first app" }
+if ($modern[1].Name -ne 'pwsh') { throw "Modern parse: unexpected second app" }
+Write-Output "==> Modern PSCustomObject parsing OK"
+
+# Legacy scoop: text table output.
+function Invoke-CommandLine {
+    param($CommandLine, $StopAtError, $PrintCommand, $Silent)
+    $null = $CommandLine, $StopAtError, $PrintCommand, $Silent
+    return @(
+        "Name      Installed Version  Latest Version  Missing Dependencies  Info"
+        "----      -----------------  --------------  --------------------  ----"
+        "7zip      24.08              24.09"
+        "git       2.46.0             2.47.0"
+    )
+}
+$legacy = @(Get-ScoopUpdatableApp)
+if ($legacy.Count -ne 2) { throw "Legacy parse: expected 2 apps, got $($legacy.Count)" }
+if ($legacy[0].Name -ne '7zip' -or $legacy[0].InstalledVersion -ne '24.08') { throw "Legacy parse: unexpected first app" }
+if ($legacy[1].Name -ne 'git' -or $legacy[1].LatestVersion -ne '2.47.0') { throw "Legacy parse: unexpected second app" }
+Write-Output "==> Legacy text parsing OK"
+
+Write-Output "==> PS 5.1 smoke guard PASSED"

--- a/tools/scoop/update-scoop.bat
+++ b/tools/scoop/update-scoop.bat
@@ -1,1 +1,10 @@
-pwsh -ExecutionPolicy Bypass -File %~dp0update-scoop.ps1 %* || exit /b 1
+@echo off
+REM Launch the Scoop update helper in a classic console (conhost) under Windows
+REM PowerShell 5.1, detached from the caller. conhost.exe bypasses the Windows 11
+REM "default terminal application" setting (which would otherwise reopen inside
+REM Windows Terminal and lock it); powershell.exe (5.1) leaves pwsh.exe unlocked.
+REM Both are required so the helper can update pwsh and Windows Terminal.
+REM The profile is loaded on purpose (no -NoProfile): on corporate machines the
+REM user profile injects proxy configuration (setProxy.ps1) that Scoop needs to
+REM reach the internet.
+start "Scoop Update" conhost.exe powershell.exe -ExecutionPolicy Bypass -File "%~dp0update-scoop.ps1" %*

--- a/tools/scoop/update-scoop.ps1
+++ b/tools/scoop/update-scoop.ps1
@@ -1,19 +1,22 @@
-﻿#Requires -Version 7.4
-
-<#
+﻿<#
 .SYNOPSIS
     Scoop Update Helper - Interactive tool to update Scoop packages.
 
 .DESCRIPTION
-    Refreshes Scoop, lists updatable apps, and lets you select which to update.
-    All logic is in lib/scoop/scoop.ps1; this script is a thin wrapper.
+    Refreshes Scoop, then loops: lists updatable apps and lets you select apps
+    to update, refresh the buckets ([R]), or quit ([Q]). Scoop failures are
+    shown and control returns to the menu, so the session never exits on error.
+
+    Runs under Windows PowerShell 5.1 (launched via update-scoop.bat in a classic
+    console) so that pwsh and Windows Terminal can be updated while it runs. All
+    logic lives in lib/scoop/scoop.ps1; this script is a thin wrapper.
 
 .EXAMPLE
     .\update-scoop.ps1
     Starts the interactive Scoop update helper.
 #>
 
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Interactive tool requires console output for press-any-key prompt')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Interactive tool requires console output for the fatal-error message')]
 [CmdletBinding()]
 param()
 
@@ -24,10 +27,8 @@ $ErrorActionPreference = 'Stop'
 
 try {
     Invoke-ScoopUpdate
-} finally {
-    if (-not (Test-RunningInCIorTestEnvironment)) {
-        Write-Host ""
-        Write-Host "Press any key to exit..."
-        $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
-    }
+}
+catch {
+    Write-Host "Fatal error: $_" -ForegroundColor Red
+    exit 1
 }


### PR DESCRIPTION
## Summary

Reworks the Scoop update helper (SC-047) so it:

1. **Survives Scoop errors** — each loop iteration is wrapped in try/catch; a failure prints in red and returns to the menu instead of exiting.
2. **Loops until you quit** — refresh once at startup, then re-check `scoop status` each iteration; menu is number(s) / `[A]ll` / `[R]efresh` / `[Q]uit`, with a keypress pause after each update.
3. **Runs under Windows PowerShell 5.1 in a classic console** — so `pwsh` and Windows Terminal can be updated while it runs.

## Key changes

- `lib/scoop/scoop.ps1`: `Invoke-ScoopUpdate` is now a resilient loop controller with a CI single-pass guard; new `Read-ScoopMenuChoice` (structured `update`/`refresh`/`quit` action), `Wait-ScoopKeyPress`, `Invoke-ScoopBucketRefresh`; `Select-ScoopApp` removed.
- `tools/scoop/update-scoop.ps1`: drop `#Requires 7.4` and the exit keypress; thin top-level try/catch.
- `tools/scoop/update-scoop.bat`: launch a detached classic `conhost.exe powershell.exe` (5.1). `conhost.exe` bypasses the Win11 "default terminal = Windows Terminal" trap. **Profile is loaded on purpose** (no `-NoProfile`) so `setProxy.ps1` gives Scoop internet on corporate machines.
- `test/bin/smoke-ps51.ps1` + `.github/workflows/test.yml`: a dependency-free CI smoke guard that dot-sources the scoop/utils libs under 5.1 and validates parsing — enforces **ADR 0001**.
- Docs: ADR 0001, `docs/architecture/` index, `docs/runbooks/scoop-update.md`, README links.

## Process change (bundled)

Establishes project policy that a **backlog item is the single canonical work artifact and must exist before design/implementation** (AGENTS.md + development-principles.md). Replaces the separate design-spec approach.

## Verification

- Scoop unit **33/33**, integration **4/4**, all lint-clean.
- Full-suite regression check against a stashed baseline: identical 17 environmental WSL `setup-user` failures with and without these changes → **zero regressions**.
- `smoke-ps51.ps1` passes under real Windows PowerShell 5.1.
- **UAT passed** on a corporate machine, including the proxy path and the Windows-Terminal-locked retry flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)