### PR TITLE
fix(proxy): stabilize px defaults for sharing (SC-048)

### DIFF
--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -38,6 +38,7 @@
 
 ### Done
 
+- [SC-048 — Stable px defaults for sharing (workers = 1, idle = 300)](sc-048.md)
 - [SC-046 — Make px `[settings]` user-configurable via px-user.ini](sc-046.md)
 - [SC-045 — Setup-proxy mode prompt: Enter defaults to Auto](sc-045.md)
 - [SC-036 — Corporate proxy for WSL without stored credentials](sc-036.md)

--- a/docs/backlog/sc-048.md
+++ b/docs/backlog/sc-048.md
@@ -1,0 +1,30 @@
+[← Back to Backlog](README.md)
+
+# [SC-048] ✅ DONE - Stable px defaults for sharing (workers = 1, idle = 300)
+
+**Status**: Done (2026-07-24)
+**Priority**: Medium
+**Component**: `tools/proxy/px-proxy.ps1` (`Get-PxDefaultSetting`, `px-user.ini` template), `tools/proxy/px-proxy.Tests.ps1`, `docs/runbooks/px-proxy.md`
+**Related**: [SC-044](sc-044.md) (raised workers/threads for bursts), [SC-046](sc-046.md) (user-configurable `[settings]`)
+
+**Summary**:
+As someone sharing px-proxy with colleagues, I want the built-in `[settings]` defaults to be a stable baseline (`workers = 1`, `idle = 300`) so that px behaves reliably out of the box on other machines, with parallelism still opt-in via `px-user.ini`.
+
+**Description**:
+Extended testing showed the current defaults (`workers = 8` from SC-044, `idle = 60`) are not stable enough to hand to other users. Lower the built-in defaults to `workers = 1` and raise `idle` to `300`. These remain user-overridable: SC-046's `px-user.ini` merge means anyone needing more parallelism can raise `workers` without editing source. `threads = 32`, `socktimeout = 300.0`, and `log = 0` are unchanged.
+
+**Scope Decisions**:
+- **Only `workers` and `idle` change**: `workers` `8 -> 1`, `idle` `60 -> 300`. This partially walks back SC-044's `workers` bump in favor of stability; extra parallelism is now opt-in via `px-user.ini` rather than the shipped default.
+- **Update all three surfaces together**: the `Get-PxDefaultSetting` map, the commented `px-user.ini` template defaults, and the runbook defaults table, so documented values match emitted values (the invariant SC-046 established).
+
+**Acceptance Criteria**:
+- [x] `Get-PxDefaultSetting` returns `workers = 1` and `idle = 300` (`threads = 32`, `socktimeout = 300.0`, `log = 0` unchanged)
+- [x] The seeded `px-user.ini` template shows `# workers = 1` and `# idle = 300`
+- [x] `docs/runbooks/px-proxy.md` defaults table shows `workers = 1` and `idle = 300`
+- [x] `px-proxy.Tests.ps1` Write-PxConfig default-settings assertions updated to `workers = 1` / `idle = 300`; user-override test still asserts untouched `idle` defaults to `300`
+- [x] px-proxy unit tests green; no new failures introduced
+
+**UAT Procedure**:
+1. [x] Delete `px.ini`, run `px-proxy start`, confirm `px.ini` `[settings]` shows `workers = 1` and `idle = 300`. (covered by unit tests; user validated defaults during px testing)
+
+[← Back to Backlog](README.md)

--- a/docs/runbooks/px-proxy.md
+++ b/docs/runbooks/px-proxy.md
@@ -118,9 +118,9 @@ Only the `[settings]` block is read; the `[proxy]` block (`server`, `listen`, `p
 | Key | Default | Purpose |
 |-----|---------|---------|
 | `log` | `0` | Log level. `0` = off; `3` = verbose `debug-*.log` for troubleshooting. |
-| `workers` | `8` | Connection worker processes. |
+| `workers` | `1` | Connection worker processes. |
 | `threads` | `32` | Threads per worker. |
-| `idle` | `60` | Seconds an idle upstream connection is kept. |
+| `idle` | `300` | Seconds an idle upstream connection is kept. |
 | `socktimeout` | `300.0` | Socket timeout (seconds) for long-running requests. |
 
 Example `px-user.ini` that turns logging on and enlarges the pool:

--- a/tools/proxy/px-proxy.Tests.ps1
+++ b/tools/proxy/px-proxy.Tests.ps1
@@ -317,9 +317,9 @@ Describe "Write-PxConfig" {
         $content | Should -Match 'listen = 127\.0\.0\.1'
         $content | Should -Match 'port = 3128'
         $content | Should -Match 'log = 0'
-        $content | Should -Match 'idle = 60'
+        $content | Should -Match 'idle = 300'
         $content | Should -Match 'socktimeout = 300\.0'
-        $content | Should -Match 'workers = 8'
+        $content | Should -Match 'workers = 1'
         $content | Should -Match 'threads = 32'
     }
 
@@ -344,7 +344,7 @@ workers = 12
         $content | Should -Match 'workers = 12'
         # Untouched keys keep their defaults.
         $content | Should -Match 'threads = 32'
-        $content | Should -Match 'idle = 60'
+        $content | Should -Match 'idle = 300'
         $content | Should -Match 'socktimeout = 300\.0'
     }
 

--- a/tools/proxy/px-proxy.ps1
+++ b/tools/proxy/px-proxy.ps1
@@ -332,8 +332,9 @@ $script:PxManagedSettingKeys = @('server', 'listen', 'port', 'auth')
 # Built-in [settings] defaults, in emission order. log defaults to 0 (quiet):
 # set log = 3 in px-user.ini to capture a debug log when troubleshooting.
 # idle/socktimeout sit above px's defaults so long AI-agent requests (Claude
-# Code, Copilot CLI) are not dropped; workers/threads sit above px's low
-# defaults (2/5) so parallel connection bursts are not refused (SC-044).
+# Code, Copilot CLI) are not dropped. workers defaults to 1 and idle to 300 for
+# a stable baseline suitable for sharing with colleagues (SC-048); raise workers
+# in px-user.ini if you need more parallelism.
 function Get-PxDefaultSetting {
     <#
     .SYNOPSIS
@@ -345,9 +346,9 @@ function Get-PxDefaultSetting {
 
     return [ordered]@{
         log         = '0'
-        workers     = '8'
+        workers     = '1'
         threads     = '32'
-        idle        = '60'
+        idle        = '300'
         socktimeout = '300.0'
     }
 }
@@ -433,11 +434,11 @@ function New-PxUserConfigTemplate {
 # Log level: 0 = off (default); 3 = verbose debug-<pid>.log for troubleshooting.
 # log = 0
 # Connection worker processes.
-# workers = 8
+# workers = 1
 # Threads per worker.
 # threads = 32
 # Seconds an idle upstream connection is kept.
-# idle = 60
+# idle = 300
 # Socket timeout (seconds) for long-running requests.
 # socktimeout = 300.0
 "@


### PR DESCRIPTION
Lower the built-in px [settings] defaults to a stable baseline suitable for handing to colleagues: workers 8 -> 1 and idle 60 -> 300. Extra parallelism stays opt-in via px-user.ini (SC-046 merge). threads, socktimeout, and log are unchanged.

Updated together so documented and emitted values match: the Get-PxDefaultSetting map, the px-user.ini template comments, the runbook defaults table, and the Write-PxConfig unit assertions.