### PR TITLE
fix(proxy): stop px unit tests from killing a real px (SC-049)

### DIFF
--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -38,6 +38,7 @@
 
 ### Done
 
+- [SC-049 — px unit tests must never kill a real px process](sc-049.md)
 - [SC-048 — Stable px defaults for sharing (workers = 1, idle = 300)](sc-048.md)
 - [SC-046 — Make px `[settings]` user-configurable via px-user.ini](sc-046.md)
 - [SC-045 — Setup-proxy mode prompt: Enter defaults to Auto](sc-045.md)

--- a/docs/backlog/sc-049.md
+++ b/docs/backlog/sc-049.md
@@ -1,0 +1,36 @@
+[← Back to Backlog](README.md)
+
+# [SC-049] ✅ DONE - px unit tests must never kill a real px process
+
+**Status**: Done (2026-07-24)
+**Priority**: High
+**Component**: `tools/proxy/px-proxy.Tests.ps1` (`Stop-PxProxy` Describe)
+**Related**: [SC-040](sc-040.md) (px tool), [SC-046](sc-046.md), [SC-048](sc-048.md)
+
+**Summary**:
+As a developer running the px unit tests on my machine, I want the suite to never touch a real running px, so that `testrunner.ps1 -Unit` does not kill the `pxw.exe` I rely on for internet access.
+
+**Description**:
+`Stop-PxProxy` (px-proxy.ps1) gracefully asks px to quit (`px --quit`) and then, if px is still running, force-kills it: `Get-Process -Name 'px','pxw' | Stop-Process -Force`. That is correct production behavior.
+
+The unit test `Stop-PxProxy` > "asks px to quit when running" **never mocked `Stop-Process` (nor `Get-Process`)**, and it stacked two `Test-PxRunning` mocks: an always-matching `-ParameterFilter { $true }` mock plus a stateful one. When the always-true mock wins the second `Test-PxRunning` check, the real force-kill branch executes and terminates whatever real `px`/`pxw` is running on the developer's machine. This was observed killing a live `pxw.exe` during a routine unit-test run.
+
+The fix is test-only: make the `Stop-PxProxy` Describe hermetic. The production `Stop-PxProxy` is unchanged.
+
+**Scope Decisions**:
+- **Defense in depth via a `BeforeEach`**: mock both `Get-Process` and `Stop-Process` for the whole `Stop-PxProxy` Describe, so no test in that block can ever reach a real process, regardless of future logic changes.
+- **Remove the ambiguous mock**: drop the redundant `Mock Test-PxRunning { $true } -ParameterFilter { $true }` so the stateful mock unambiguously governs the graceful-exit path.
+- **Cover the force-kill branch on purpose**: add a test where px ignores `--quit` (Test-PxRunning stays true), `Get-Process` returns a fake process, and `Stop-Process` is asserted invoked (mocked). This both documents the branch and proves the safety net works.
+- **No production change**: the only place a real `Stop-Process` could be hit is this Describe; other Describes mock `Stop-PxProxy`, and the "Script entry point" test is skipped when px is running and only runs `stop` (a no-op when px is absent).
+
+**Acceptance Criteria**:
+- [x] The `Stop-PxProxy` Describe mocks `Get-Process` and `Stop-Process` (via `BeforeEach`) so no real process can be touched
+- [x] The redundant always-true `Test-PxRunning` mock is removed; the graceful-exit test asserts `Stop-Process` is invoked 0 times
+- [x] A new test covers the force-kill branch: px still running after `--quit` leads to `Stop-Process` being invoked (against a mocked `Get-Process` result)
+- [x] `Stop-PxProxy` production code is unchanged
+- [x] px-proxy unit tests green; running the px unit suite does not terminate a running `pxw.exe`
+
+**UAT Procedure**:
+1. [x] With a real `pxw.exe` running, run the px-proxy unit suite and confirm the same `pxw.exe` (same PID) is still running afterwards. (verified: PID unchanged across the run)
+
+[← Back to Backlog](README.md)

--- a/tools/proxy/px-proxy.Tests.ps1
+++ b/tools/proxy/px-proxy.Tests.ps1
@@ -404,23 +404,42 @@ Describe "Install-PxProxy" {
 }
 
 Describe "Stop-PxProxy" {
+    BeforeEach {
+        # Safety net (SC-049): never let a unit test reach a real px process.
+        # Stop-PxProxy force-kills via Get-Process | Stop-Process when px ignores
+        # --quit; mocking both here guarantees no test can terminate a running px.
+        Mock Get-Process { }
+        Mock Stop-Process { }
+    }
+
     It "does nothing when px is not running" {
         Mock Test-PxRunning { $false }
         Mock Invoke-CommandLine { }
         Stop-PxProxy
         Should -Invoke Invoke-CommandLine -Times 0
+        Should -Invoke Stop-Process -Times 0
     }
 
-    It "asks px to quit when running" {
-        Mock Test-PxRunning { $true } -ParameterFilter { $true }
+    It "asks px to quit when running and does not force-kill once it exits" {
         Mock Get-PxExecutable { 'C:\scoop\shims\px.exe' }
         Mock Invoke-CommandLine { }
         Mock Start-Sleep { }
-        # After quit, no longer running
+        # Running before --quit, gone after: the stateful mock alone governs.
         $script:quitCalled = $false
         Mock Test-PxRunning { if ($script:quitCalled) { $false } else { $script:quitCalled = $true; $true } }
         Stop-PxProxy
         Should -Invoke Invoke-CommandLine -Times 1 -ParameterFilter { $CommandLine -match '^& ".*" --quit$' }
+        Should -Invoke Stop-Process -Times 0
+    }
+
+    It "force-kills px when it ignores --quit" {
+        Mock Get-PxExecutable { 'C:\scoop\shims\px.exe' }
+        Mock Invoke-CommandLine { }
+        Mock Start-Sleep { }
+        Mock Test-PxRunning { $true }   # still running after --quit
+        Mock Get-Process { @([pscustomobject]@{ Id = 4242 }) }
+        Stop-PxProxy
+        Should -Invoke Stop-Process -Times 1 -ParameterFilter { $Id -eq 4242 }
     }
 }
 


### PR DESCRIPTION
Stop-PxProxy force-kills via Get-Process | Stop-Process when px ignores --quit. The Stop-PxProxy unit test never mocked Stop-Process and stacked an always-true Test-PxRunning mock over a stateful one, so the real force-kill branch could run and terminate a developer's live pxw.exe during a routine unit run.

Make the Stop-PxProxy Describe hermetic: mock Get-Process and Stop-Process in a BeforeEach, drop the redundant always-true Test-PxRunning mock, and add a test that exercises the force-kill branch against a mocked process. Production Stop-PxProxy is unchanged. Verified: pxw PID unchanged across the px unit run.